### PR TITLE
fix: narrow catch-all `with _ ->` to `Type_error` in message_of_yojson

### DIFF
--- a/lib/jsonrpc.ml
+++ b/lib/jsonrpc.ml
@@ -131,8 +131,8 @@ let message_of_yojson json =
       Result.map (fun e -> Error e) (error_response_of_yojson json)
     | _ ->
       Error "Invalid JSON-RPC message structure"
-  with _ ->
-    Error "Failed to parse JSON-RPC message"
+  with Yojson.Safe.Util.Type_error (msg, _) ->
+    Error (Printf.sprintf "Failed to parse JSON-RPC message: %s" msg)
 
 (** Convert a JSON-RPC message to JSON *)
 let message_to_yojson = function

--- a/test/test_jsonrpc.ml
+++ b/test/test_jsonrpc.ml
@@ -178,6 +178,14 @@ let test_message_parse_invalid () =
     true
     (Result.is_error (Jsonrpc.message_of_yojson j))
 
+let test_message_parse_non_object () =
+  let cases = [`String "hello"; `Int 42; `List [`Int 1]; `Bool true] in
+  List.iter (fun j ->
+    Alcotest.(check bool) "non-object json returns Error"
+      true
+      (Result.is_error (Jsonrpc.message_of_yojson j))
+  ) cases
+
 (* --- make_* helpers --- *)
 
 let test_make_request () =
@@ -314,6 +322,7 @@ let () =
       Alcotest.test_case "parse response" `Quick test_message_parse_response;
       Alcotest.test_case "parse error" `Quick test_message_parse_error;
       Alcotest.test_case "parse invalid" `Quick test_message_parse_invalid;
+      Alcotest.test_case "parse non-object" `Quick test_message_parse_non_object;
     ];
     "make_helpers", [
       Alcotest.test_case "make_request" `Quick test_make_request;


### PR DESCRIPTION
## Summary
- `jsonrpc.ml:134`: `with _ ->` narrowed to `with Yojson.Safe.Util.Type_error (msg, _) ->`
- Prevents silent swallowing of `Out_of_memory`/`Stack_overflow` in SDK core parser
- Error message now includes the `Type_error` description for diagnostics
- Added regression test for non-object JSON input (`test_message_parse_non_object`)

## Test plan
- [x] `dune runtest --root .` — 29/29 pass (all suites)
- [x] New test covers `String`, `Int`, `List`, `Bool` non-object inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)