### PR TITLE
fix: restore Protocol and Resources compatibility modules

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -4,4 +4,4 @@
  (libraries yojson uri unix)
  (preprocess
   (pps ppx_deriving_yojson))
- (modules mcp_protocol jsonrpc mcp_types error_codes http_negotiation version mcp_result session logging sampling notifications transport))
+ (modules mcp_protocol jsonrpc mcp_types error_codes http_negotiation version mcp_result session logging sampling notifications transport protocol resources))

--- a/lib/mcp_protocol.ml
+++ b/lib/mcp_protocol.ml
@@ -60,6 +60,14 @@ module Sampling = Sampling
 (** MCP method string constants *)
 module Notifications = Notifications
 
+(** {1 Backward Compatibility Modules} *)
+
+(** Legacy Protocol module for existing code *)
+module Protocol = Protocol
+
+(** Legacy Resources module for existing code *)
+module Resources = Resources
+
 (** {1 Convenience Re-exports} *)
 
 (** Protocol version string *)

--- a/lib/mcp_protocol.mli
+++ b/lib/mcp_protocol.mli
@@ -15,6 +15,8 @@ module Session = Session
 module Logging = Logging
 module Sampling = Sampling
 module Notifications = Notifications
+module Protocol = Protocol
+module Resources = Resources
 
 (** {1 Convenience Re-exports} *)
 

--- a/lib/protocol.ml
+++ b/lib/protocol.ml
@@ -1,0 +1,90 @@
+(** MCP Protocol - Backward compatibility module.
+
+    Re-exports from new modules for existing code compatibility.
+    New code should use Mcp_types, Jsonrpc, Error_codes directly.
+*)
+
+let protocol_version = Version.latest
+
+type tool = Mcp_types.tool
+type resource = Mcp_types.resource
+type server_info = Mcp_types.server_info
+
+type capabilities = {
+  tools: bool;
+  resources: bool;
+}
+
+let tool_to_json = Mcp_types.tool_to_yojson
+let resource_to_json = Mcp_types.resource_to_yojson
+let server_info_to_json = Mcp_types.server_info_to_yojson
+
+let capabilities_to_json (c : capabilities) =
+  let items = [] in
+  let items = if c.tools then ("tools", `Assoc []) :: items else items in
+  let items = if c.resources then ("resources", `Assoc []) :: items else items in
+  `Assoc items
+
+let make_response ~id result =
+  Jsonrpc.make_response_json ~id ~result
+
+let make_error ~id code message =
+  Jsonrpc.make_error_json ~id ~code ~message ()
+
+module ErrorCode = struct
+  let parse_error = Error_codes.parse_error
+  let invalid_request = Error_codes.invalid_request
+  let method_not_found = Error_codes.method_not_found
+  let invalid_params = Error_codes.invalid_params
+  let internal_error = Error_codes.internal_error
+end
+
+let get_string key json =
+  let open Yojson.Safe.Util in
+  try Some (json |> member key |> to_string) with _ -> None
+
+let get_int key json =
+  let open Yojson.Safe.Util in
+  try Some (json |> member key |> to_int) with _ -> None
+
+let get_bool key json =
+  let open Yojson.Safe.Util in
+  try Some (json |> member key |> to_bool) with _ -> None
+
+let get_string_list key json =
+  let open Yojson.Safe.Util in
+  try
+    Some (json |> member key |> to_list |> List.map to_string)
+  with _ ->
+    match get_string key json with
+    | Some s -> (try Some (Yojson.Safe.from_string s |> to_list |> List.map to_string) with _ -> None)
+    | None -> None
+
+let text_content text =
+  `Assoc [
+    ("type", `String "text");
+    ("text", `String text);
+  ]
+
+let tool_result contents =
+  `Assoc [("content", `List contents)]
+
+let make_initialize_response ~id ~server_info ~capabilities =
+  make_response ~id (`Assoc [
+    ("protocolVersion", `String protocol_version);
+    ("serverInfo", server_info_to_json server_info);
+    ("capabilities", capabilities_to_json capabilities);
+  ])
+
+let make_tools_list_response ~id tools =
+  make_response ~id (`Assoc [
+    ("tools", `List (List.map tool_to_json tools));
+  ])
+
+let make_resources_list_response ~id resources =
+  make_response ~id (`Assoc [
+    ("resources", `List (List.map resource_to_json resources));
+  ])
+
+let make_tool_call_response ~id text =
+  make_response ~id (tool_result [text_content text])

--- a/lib/resources.ml
+++ b/lib/resources.ml
@@ -1,0 +1,29 @@
+(** MCP Resources/ResourceTemplates helpers.
+
+    Backward compatibility module.
+    Re-exports resource types from Mcp_types with helpers for resources/* methods.
+*)
+
+type resource = Mcp_types.resource
+type resource_template = Mcp_types.resource_template
+type content = Mcp_types.resource_contents
+
+let resource_template_to_json = Mcp_types.resource_template_to_yojson
+
+let content_to_json (c : content) =
+  Mcp_types.resource_contents_to_yojson c
+
+let list_result (resources : resource list) =
+  `Assoc [
+    ("resources", `List (List.map Mcp_types.resource_to_yojson resources));
+  ]
+
+let templates_list_result (templates : resource_template list) =
+  `Assoc [
+    ("resourceTemplates", `List (List.map resource_template_to_json templates));
+  ]
+
+let read_result (contents : content list) =
+  `Assoc [
+    ("contents", `List (List.map content_to_json contents));
+  ]

--- a/test/dune
+++ b/test/dune
@@ -9,6 +9,7 @@
   test_mcp_result
   test_logging
   test_sampling
+  test_backward_compat
   test_notifications)
  (libraries mcp_protocol alcotest))
 

--- a/test/test_backward_compat.ml
+++ b/test/test_backward_compat.ml
@@ -1,0 +1,68 @@
+open Alcotest
+
+module Protocol = Mcp_protocol.Protocol
+module Resources = Mcp_protocol.Resources
+module Types = Mcp_protocol.Mcp_types
+module Jsonrpc = Mcp_protocol.Jsonrpc
+
+let test_protocol_capabilities_to_json () =
+  let json = Protocol.capabilities_to_json { tools = true; resources = true } in
+  let open Yojson.Safe.Util in
+  check bool "tools present" true (json |> member "tools" <> `Null);
+  check bool "resources present" true (json |> member "resources" <> `Null)
+
+let test_protocol_initialize_response () =
+  let server_info : Protocol.server_info = {
+    name = "compat-test";
+    version = "1.0.0";
+  } in
+  let json =
+    Protocol.make_initialize_response
+      ~id:(Jsonrpc.Int 1)
+      ~server_info
+      ~capabilities:{ tools = true; resources = false }
+  in
+  let open Yojson.Safe.Util in
+  check string "jsonrpc" "2.0" (json |> member "jsonrpc" |> to_string);
+  check string "protocolVersion" Mcp_protocol.protocol_version
+    (json |> member "result" |> member "protocolVersion" |> to_string);
+  check string "server name" "compat-test"
+    (json |> member "result" |> member "serverInfo" |> member "name" |> to_string)
+
+let test_resources_helpers () =
+  let resource : Resources.resource = {
+    uri = "memory://x";
+    name = "X";
+    description = Some "desc";
+    mime_type = Some "text/plain";
+  } in
+  let template : Resources.resource_template = {
+    uri_template = "memory://{id}";
+    name = "T";
+    description = Some "desc";
+    mime_type = Some "text/plain";
+  } in
+  let content : Resources.content = {
+    uri = "memory://x";
+    mime_type = Some "text/plain";
+    text = Some "hello";
+    blob = None;
+  } in
+  let open Yojson.Safe.Util in
+  check int "resources count" 1
+    (Resources.list_result [resource] |> member "resources" |> to_list |> List.length);
+  check int "templates count" 1
+    (Resources.templates_list_result [template] |> member "resourceTemplates" |> to_list |> List.length);
+  check int "contents count" 1
+    (Resources.read_result [content] |> member "contents" |> to_list |> List.length)
+
+let () =
+  run "backward_compat" [
+    ("protocol", [
+      test_case "capabilities_to_json" `Quick test_protocol_capabilities_to_json;
+      test_case "initialize_response" `Quick test_protocol_initialize_response;
+    ]);
+    ("resources", [
+      test_case "helper results" `Quick test_resources_helpers;
+    ]);
+  ]


### PR DESCRIPTION
## Summary
- restore legacy  and  modules on top of the current SDK surface
- re-export the compatibility modules from 
- add backward-compat regression tests for legacy response/resource helpers

## Verification
- 
- Testing `backward_compat'.
This run has ID `AAAU409C'.

  [OK]          protocol           0   capabilities_to_json.
  [OK]          protocol           1   initialize_response.
  [OK]          resources          0   helper results.

Full test results in `~/me/_build/_tests/backward_compat'.
Test Successful in 0.001s. 3 tests run.
- Testing `Jsonrpc'.
This run has ID `YDGTZBR9'.

  [OK]          id                         0   string round-trip.
  [OK]          id                         1   int round-trip.
  [OK]          id                         2   null round-trip.
  [OK]          id                         3   invalid.
  [OK]          request                    0   round-trip.
  [OK]          request                    1   with params.
  [OK]          notification               0   round-trip.
  [OK]          response                   0   round-trip.
  [OK]          error_response             0   round-trip.
  [OK]          message_parsing            0   parse request.
  [OK]          message_parsing            1   parse notification.
  [OK]          message_parsing            2   parse response.
  [OK]          message_parsing            3   parse error.
  [OK]          message_parsing            4   parse invalid.
  [OK]          make_helpers               0   make_request.
  [OK]          make_helpers               1   make_notification.
  [OK]          make_helpers               2   make_response.
  [OK]          make_helpers               3   make_error.
  [OK]          round_trip                 0   message_to_yojson.
  [OK]          message_of_string          0   valid.
  [OK]          message_of_string          1   invalid json.
  [OK]          inbound                    0   request.
  [OK]          inbound                    1   notification.
  [OK]          inbound                    2   reject response.
  [OK]          wire_json_helpers          0   request json.
  [OK]          wire_json_helpers          1   notification json.
  [OK]          wire_json_helpers          2   response json.
  [OK]          wire_json_helpers          3   error json.

Full test results in `~/me/_build/_tests/Jsonrpc'.
Test Successful in 0.002s. 28 tests run.
