### PR TITLE
fix: add timeout to read_response and warn on parse_list_field drops

### DIFF
--- a/eio/client.ml
+++ b/eio/client.ml
@@ -2,36 +2,47 @@
 
 open Mcp_protocol
 
+let default_timeout = 30.0
+
 type t = {
   transport: Stdio_transport.t;
+  with_timeout: 'a. (unit -> 'a) -> 'a;
+  timeout: float;
   mutable next_id: int;
 }
 
-let create ~stdin ~stdout = {
+let create ~clock ?(timeout = default_timeout) ~stdin ~stdout () = {
   transport = Stdio_transport.create ~stdin ~stdout;
+  with_timeout = (fun f -> Eio.Time.with_timeout_exn clock timeout f);
+  timeout;
   next_id = 1;
 }
 
 (* ── request/response ─────────────────────────────── *)
 
 let read_response t expected_id =
-  let rec loop () =
-    match Stdio_transport.read t.transport with
-    | None -> Error "Connection closed"
-    | Some (Error e) -> Error (Printf.sprintf "Read error: %s" e)
-    | Some (Ok msg) ->
-      begin match msg with
-      | Jsonrpc.Response resp when resp.id = expected_id ->
-        Ok resp.result
-      | Jsonrpc.Error err when err.id = expected_id ->
-        Error err.error.message
-      | Jsonrpc.Notification _ ->
-        loop ()
-      | _ ->
-        loop ()
-      end
+  let read_loop () =
+    let rec loop () =
+      match Stdio_transport.read t.transport with
+      | None -> Error "Connection closed"
+      | Some (Error e) -> Error (Printf.sprintf "Read error: %s" e)
+      | Some (Ok msg) ->
+        begin match msg with
+        | Jsonrpc.Response resp when resp.id = expected_id ->
+          Ok resp.result
+        | Jsonrpc.Error err when err.id = expected_id ->
+          Error err.error.message
+        | Jsonrpc.Notification _ ->
+          loop ()
+        | _ ->
+          loop ()
+        end
+    in
+    loop ()
   in
-  loop ()
+  try t.with_timeout read_loop
+  with Eio.Time.Timeout ->
+    Error (Printf.sprintf "Response timed out after %.0fs" t.timeout)
 
 let send_request t ~method_ ?params () =
   let id = Jsonrpc.Int t.next_id in
@@ -52,11 +63,21 @@ let parse_list_field field_name parser result =
   | `Assoc fields ->
     begin match List.assoc_opt field_name fields with
     | Some (`List items) ->
+      let total = List.length items in
       let parsed = List.filter_map (fun j ->
         match parser j with
         | Ok v -> Some v
-        | Error _ -> None
+        | Error e ->
+          Printf.eprintf
+            "[mcp-client] warning: dropped unparseable '%s' item: %s\n%!"
+            field_name e;
+          None
       ) items in
+      let parsed_count = List.length parsed in
+      if parsed_count < total then
+        Printf.eprintf
+          "[mcp-client] warning: parsed %d/%d '%s' items (%d dropped)\n%!"
+          parsed_count total field_name (total - parsed_count);
       Ok parsed
     | _ -> Error (Printf.sprintf "Missing '%s' array in response" field_name)
     end

--- a/eio/client.mli
+++ b/eio/client.mli
@@ -25,9 +25,12 @@ open Mcp_protocol
 type t
 
 (** Create a client connected to the given I/O flows.
+    @param clock  Eio clock used for response timeouts.
+    @param timeout Maximum seconds to wait for a response (default: 30.0).
     @param stdin  Source to read server responses from.
     @param stdout Sink to write requests to the server. *)
-val create : stdin:_ Eio.Flow.source -> stdout:_ Eio.Flow.sink -> t
+val create : clock:_ Eio.Time.clock -> ?timeout:float ->
+  stdin:_ Eio.Flow.source -> stdout:_ Eio.Flow.sink -> unit -> t
 
 (** {2 Lifecycle} *)
 

--- a/examples/echo_client.ml
+++ b/examples/echo_client.ml
@@ -21,8 +21,9 @@ let () =
   Eio.Flow.close child_stdin_r;
   Eio.Flow.close child_stdout_w;
   (* Create MCP client *)
-  let client = Mcp_protocol_eio.Client.create
-    ~stdin:child_stdout_r ~stdout:child_stdin_w
+  let clock = Eio.Stdenv.clock env in
+  let client = Mcp_protocol_eio.Client.create ~clock
+    ~stdin:child_stdout_r ~stdout:child_stdin_w ()
   in
   (* Initialize *)
   begin match Mcp_protocol_eio.Client.initialize client

--- a/test/test_client.ml
+++ b/test/test_client.ml
@@ -7,14 +7,15 @@ open Mcp_protocol
 (** Run a client test with pre-built server responses.
     Returns (callback_result, list_of_json_messages_client_sent). *)
 let run_client_test responses fn =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   let input_str =
     String.concat "\n" (List.map Yojson.Safe.to_string responses) ^ "\n"
   in
   let source = Eio.Flow.string_source input_str in
   let buf = Buffer.create 1024 in
   let sink = Eio.Flow.buffer_sink buf in
-  let client = Mcp_protocol_eio.Client.create ~stdin:source ~stdout:sink in
+  let clock = Eio.Stdenv.clock env in
+  let client = Mcp_protocol_eio.Client.create ~clock ~stdin:source ~stdout:sink () in
   let result = fn client in
   let output = Buffer.contents buf in
   let sent =

--- a/test/test_integration.ml
+++ b/test/test_integration.ml
@@ -50,7 +50,7 @@ let make_server () =
     Creates two pipes, runs server in one fiber and client callback in another.
     Closes client-to-server pipe when done to trigger server EOF. *)
 let run_integration fn =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   (* Pipe A: client → server *)
   let c2s_r, c2s_w = Eio_unix.pipe sw in
@@ -58,11 +58,12 @@ let run_integration fn =
   let s2c_r, s2c_w = Eio_unix.pipe sw in
   let server = make_server () in
   let result = ref (Error "test did not run") in
+  let clock = Eio.Stdenv.clock env in
   Eio.Fiber.both
     (fun () ->
       Mcp_protocol_eio.Server.run server ~stdin:c2s_r ~stdout:s2c_w)
     (fun () ->
-      let client = Mcp_protocol_eio.Client.create ~stdin:s2c_r ~stdout:c2s_w in
+      let client = Mcp_protocol_eio.Client.create ~clock ~stdin:s2c_r ~stdout:c2s_w () in
       result := fn client;
       Mcp_protocol_eio.Client.close client;
       (* Close write end so server sees EOF *)


### PR DESCRIPTION
## Summary
- `read_response` now has 30s timeout via `Eio.Time.with_timeout_exn` (prevents indefinite blocking)
- `parse_list_field` logs per-item parse errors and summary count when items are dropped
- **Breaking**: `Client.create` now requires `~clock` parameter

## Test plan
- [x] `dune build` — compiles clean
- [x] `dune runtest` — 267/267 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)