### PR TITLE
fix: validate_state constant-time + review test coverage

### DIFF
--- a/http/oauth_client.ml
+++ b/http/oauth_client.ml
@@ -261,17 +261,20 @@ let generate_state () =
   base64url_encode (Mirage_crypto_rng.generate 24)
 
 (** Validate that the received state matches the expected state.
-    Constant-time comparison to prevent timing attacks. *)
+    Constant-time comparison to prevent timing attacks.
+    Compares over max(len_expected, len_received) to avoid leaking
+    the expected string's length through early return. *)
 let validate_state ~expected ~received =
-  let len_expected = String.length expected in
-  let len_received = String.length received in
-  if len_expected <> len_received then false
-  else
-    let result = ref 0 in
-    for i = 0 to len_expected - 1 do
-      result := !result lor (Char.code expected.[i] lxor Char.code received.[i])
-    done;
-    !result = 0
+  let len_e = String.length expected in
+  let len_r = String.length received in
+  let result = ref (len_e lxor len_r) in
+  let max_len = max len_e len_r in
+  for i = 0 to max_len - 1 do
+    let ce = if i < len_e then Char.code expected.[i] else 0 in
+    let cr = if i < len_r then Char.code received.[i] else 0 in
+    result := !result lor (ce lxor cr)
+  done;
+  !result = 0
 
 (* ── bearer token injection ─────────────────── *)
 

--- a/test/test_bug_fixes.ml
+++ b/test/test_bug_fixes.ml
@@ -166,6 +166,17 @@ let test_m3_embedded_resource_with_blob () =
   | Ok r -> Alcotest.(check (option string)) "blob" (Some "AQID") r.blob
   | Error e -> Alcotest.fail e
 
+let test_m3_embedded_resource_text_null () =
+  (* explicit "text": null should be treated as absent (None),
+     so a resource with only text:null and no blob is rejected *)
+  let j = `Assoc [
+    ("uri", `String "file:///test.txt");
+    ("text", `Null);
+  ] in
+  match Mcp_types.embedded_resource_of_yojson j with
+  | Error _ -> () (* expected: null text = no content *)
+  | Ok _ -> Alcotest.fail "M3: text:null with no blob should be rejected"
+
 (* ── M4: type-safe content constructors ──────── *)
 
 let test_m4_make_text_content () =
@@ -205,6 +216,12 @@ let test_l2_generate_state_length () =
   let state = Oauth_client.generate_state () in
   Alcotest.(check bool) "state is non-empty"
     true (String.length state > 0)
+
+let test_l2_generate_state_unique () =
+  let s1 = Oauth_client.generate_state () in
+  let s2 = Oauth_client.generate_state () in
+  Alcotest.(check bool) "two states differ"
+    true (s1 <> s2)
 
 let test_l2_validate_state_match () =
   let state = "abc123xyz" in
@@ -261,6 +278,7 @@ let () =
       Alcotest.test_case "no content fails" `Quick test_m3_embedded_resource_no_content;
       Alcotest.test_case "with text succeeds" `Quick test_m3_embedded_resource_with_text;
       Alcotest.test_case "with blob succeeds" `Quick test_m3_embedded_resource_with_blob;
+      Alcotest.test_case "text null rejected" `Quick test_m3_embedded_resource_text_null;
     ];
     "M4_content_constructors", [
       Alcotest.test_case "make_text_content" `Quick test_m4_make_text_content;
@@ -271,6 +289,7 @@ let () =
     ];
     "L2_state_param", [
       Alcotest.test_case "generate non-empty" `Quick test_l2_generate_state_length;
+      Alcotest.test_case "generate unique" `Quick test_l2_generate_state_unique;
       Alcotest.test_case "validate match" `Quick test_l2_validate_state_match;
       Alcotest.test_case "validate mismatch" `Quick test_l2_validate_state_mismatch;
       Alcotest.test_case "validate length mismatch" `Quick test_l2_validate_state_length_mismatch;


### PR DESCRIPTION
## Summary

v0.12.2 셀프 리뷰에서 발견된 2건 수정.

### 1. validate_state timing leak 수정
- 기존: `if len_expected <> len_received then false` early return → 길이 정보 누출
- 수정: `len_e lxor len_r`를 result에 포함, `max(len_e, len_r)` 길이로 XOR 루프
- constant-time 보장 범위가 길이 불일치 케이스까지 확장

### 2. 테스트 보강 (2건 추가)
- M3 `text:null` 명시적 null 거부 테스트
- L2 `generate_state` 유니크성 테스트

리뷰어가 지적한 M5 event_counter는 이미 `Atomic.t` 적용 완료 (오탐 확인).

## Test plan
- [x] 25개 회귀 테스트 통과 (was 23)
- [x] 전체 테스트 스위트 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)