### PR TITLE
ci: add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        ocaml-compiler: ['5.2', '5.3']
+        include:
+          - os: ubuntu-latest
+            ocaml-compiler: '5.4'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Install dependencies
+        run: opam install . --deps-only --with-test
+
+      - name: Build
+        run: opam exec -- dune build
+
+      - name: Run tests
+        run: opam exec -- dune runtest
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.4'
+
+      - name: Install dependencies
+        run: opam install . --deps-only
+
+      - name: Check opam files are up to date
+        run: opam exec -- dune build @install && git diff --exit-code *.opam


### PR DESCRIPTION
## Summary

CI가 없던 프로젝트에 GitHub Actions 워크플로우 추가.

### Build + Test Job
- **Matrix**: OCaml 5.2, 5.3 (ubuntu + macos), 5.4 (ubuntu)
- `opam install --deps-only --with-test` → `dune build` → `dune runtest`
- `fail-fast: false`로 독립 실행

### Lint Job
- opam 파일이 dune-project과 동기화되어 있는지 검증
- `dune build @install` + `git diff --exit-code *.opam`

## Test plan
- [x] CI가 PR에서 자동 실행되는지 확인 (이 PR 자체가 트리거)
- [x] YAML 문법 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)