### PR TITLE
test: oauth_client + handler unit tests (490 total)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -45,3 +45,11 @@
 (tests
  (names test_oauth_discovery)
  (libraries mcp_protocol mcp_protocol_http eio eio_main cohttp-eio alcotest yojson str))
+
+(tests
+ (names test_oauth_client)
+ (libraries mcp_protocol mcp_protocol_http eio eio_main cohttp-eio alcotest yojson str))
+
+(tests
+ (names test_handler)
+ (libraries mcp_protocol mcp_protocol_eio alcotest yojson))

--- a/test/test_handler.ml
+++ b/test/test_handler.ml
@@ -1,0 +1,299 @@
+(** Unit tests for Handler module.
+
+    Tests registration, accessors, capabilities, and dispatch logic
+    without requiring a real transport. *)
+
+open Mcp_protocol
+
+module Handler = Mcp_protocol_eio.Handler
+
+let json = Alcotest.testable
+  (fun fmt j -> Format.pp_print_string fmt (Yojson.Safe.to_string j))
+  (fun a b -> Yojson.Safe.equal a b)
+
+(* ── dummy context ────────────────────────────── *)
+
+let dummy_ctx : Handler.context = {
+  send_notification = (fun ~method_:_ ~params:_ -> Ok ());
+  send_log = (fun _ _ -> Ok ());
+  send_progress = (fun ~token:_ ~progress:_ ~total:_ -> Ok ());
+  request_sampling = (fun _ -> Error "not supported");
+  request_roots_list = (fun () -> Error "not supported");
+  request_elicitation = (fun _ -> Error "not supported");
+}
+
+(* ── create + accessors ──────────────────────── *)
+
+let test_create_basic () =
+  let h = Handler.create ~name:"test" ~version:"1.0" () in
+  Alcotest.(check string) "name" "test" (Handler.name h);
+  Alcotest.(check string) "version" "1.0" (Handler.version h);
+  Alcotest.(check (option string)) "no instructions" None (Handler.instructions h)
+
+let test_create_with_instructions () =
+  let h = Handler.create ~name:"s" ~version:"1" ~instructions:"help text" () in
+  Alcotest.(check (option string)) "instructions"
+    (Some "help text") (Handler.instructions h)
+
+let test_empty_collections () =
+  let h = Handler.create ~name:"s" ~version:"1" () in
+  Alcotest.(check int) "no tools" 0 (List.length (Handler.tools h));
+  Alcotest.(check int) "no resources" 0 (List.length (Handler.resources h));
+  Alcotest.(check int) "no prompts" 0 (List.length (Handler.prompts h));
+  Alcotest.(check (list string)) "no subscribed" [] (Handler.subscribed_uris h)
+
+(* ── tool registration ───────────────────────── *)
+
+let echo_handler _ctx _name _args = Ok (Mcp_types.tool_result_of_text "echo")
+
+let test_add_tool () =
+  let tool = Mcp_types.make_tool ~name:"echo" ~description:"Echo tool" () in
+  let h = Handler.create ~name:"s" ~version:"1" ()
+    |> Handler.add_tool tool echo_handler in
+  Alcotest.(check int) "one tool" 1 (List.length (Handler.tools h));
+  let t = List.hd (Handler.tools h) in
+  Alcotest.(check string) "tool name" "echo" t.name
+
+let test_add_multiple_tools () =
+  let t1 = Mcp_types.make_tool ~name:"a" () in
+  let t2 = Mcp_types.make_tool ~name:"b" () in
+  let h = Handler.create ~name:"s" ~version:"1" ()
+    |> Handler.add_tool t1 echo_handler
+    |> Handler.add_tool t2 echo_handler in
+  Alcotest.(check int) "two tools" 2 (List.length (Handler.tools h))
+
+let test_duplicate_tool_replaces () =
+  let t1 = Mcp_types.make_tool ~name:"dup" ~description:"first" () in
+  let t2 = Mcp_types.make_tool ~name:"dup" ~description:"second" () in
+  let h = Handler.create ~name:"s" ~version:"1" ()
+    |> Handler.add_tool t1 echo_handler
+    |> Handler.add_tool t2 echo_handler in
+  Alcotest.(check int) "still one" 1 (List.length (Handler.tools h));
+  Alcotest.(check (option string)) "second wins"
+    (Some "second") (List.hd (Handler.tools h)).description
+
+(* ── resource registration ───────────────────── *)
+
+let test_add_resource () =
+  let res = Mcp_types.make_resource ~uri:"file:///test" ~name:"test" () in
+  let handler _ctx _uri = Ok [{ Mcp_types.uri = "file:///test"; mime_type = None; text = Some "data"; blob = None }] in
+  let h = Handler.create ~name:"s" ~version:"1" ()
+    |> Handler.add_resource res handler in
+  Alcotest.(check int) "one resource" 1 (List.length (Handler.resources h))
+
+(* ── prompt registration ─────────────────────── *)
+
+let test_add_prompt () =
+  let prompt = Mcp_types.make_prompt ~name:"greet" () in
+  let handler _ctx _name _args = Ok Mcp_types.{ description = None; messages = [] } in
+  let h = Handler.create ~name:"s" ~version:"1" ()
+    |> Handler.add_prompt prompt handler in
+  Alcotest.(check int) "one prompt" 1 (List.length (Handler.prompts h))
+
+(* ── capabilities ────────────────────────────── *)
+
+let test_capabilities_empty () =
+  let h = Handler.create ~name:"s" ~version:"1" () in
+  let caps = Handler.server_capabilities h in
+  Alcotest.(check (option json)) "no tools cap" None caps.tools;
+  Alcotest.(check (option json)) "no resources cap" None caps.resources;
+  Alcotest.(check (option json)) "no prompts cap" None caps.prompts;
+  (* logging is always present *)
+  Alcotest.(check bool) "has logging" true (caps.logging <> None)
+
+let test_capabilities_with_tools () =
+  let tool = Mcp_types.make_tool ~name:"t" () in
+  let h = Handler.create ~name:"s" ~version:"1" ()
+    |> Handler.add_tool tool echo_handler in
+  let caps = Handler.server_capabilities h in
+  Alcotest.(check bool) "tools cap present" true (caps.tools <> None)
+
+(* ── dispatch: initialize ────────────────────── *)
+
+let dispatch_request h method_ ?params () =
+  let req = Jsonrpc.make_request ~id:(Jsonrpc.Int 1) ~method_ ?params () in
+  let log_ref = ref Logging.Warning in
+  Handler.dispatch h dummy_ctx log_ref req
+
+let test_dispatch_initialize () =
+  let h = Handler.create ~name:"test-server" ~version:"2.0" () in
+  let params = `Assoc [
+    ("protocolVersion", `String "2025-11-25");
+    ("capabilities", `Assoc []);
+    ("clientInfo", `Assoc [("name", `String "test"); ("version", `String "1.0")]);
+  ] in
+  match dispatch_request h "initialize" ~params () with
+  | Some (Response r) ->
+    (match r.result with
+     | `Assoc fields ->
+       (match List.assoc_opt "serverInfo" fields with
+        | Some (`Assoc info) ->
+          Alcotest.(check (option (testable
+            (fun fmt j -> Format.pp_print_string fmt (Yojson.Safe.to_string j))
+            (fun a b -> a = b))))
+            "server name" (Some (`String "test-server"))
+            (List.assoc_opt "name" info)
+        | _ -> Alcotest.fail "missing serverInfo")
+     | _ -> Alcotest.fail "expected assoc result")
+  | _ -> Alcotest.fail "expected Response"
+
+(* ── dispatch: ping ──────────────────────────── *)
+
+let test_dispatch_ping () =
+  let h = Handler.create ~name:"s" ~version:"1" () in
+  match dispatch_request h "ping" () with
+  | Some (Response r) ->
+    Alcotest.(check json) "empty result" (`Assoc []) r.result
+  | _ -> Alcotest.fail "expected Response"
+
+(* ── dispatch: tools/list ────────────────────── *)
+
+let test_dispatch_tools_list () =
+  let tool = Mcp_types.make_tool ~name:"echo" ~description:"desc" () in
+  let h = Handler.create ~name:"s" ~version:"1" ()
+    |> Handler.add_tool tool echo_handler in
+  match dispatch_request h "tools/list" () with
+  | Some (Response r) ->
+    (match r.result with
+     | `Assoc fields ->
+       (match List.assoc_opt "tools" fields with
+        | Some (`List tools) ->
+          Alcotest.(check int) "one tool" 1 (List.length tools)
+        | _ -> Alcotest.fail "missing tools array")
+     | _ -> Alcotest.fail "expected assoc")
+  | _ -> Alcotest.fail "expected Response"
+
+(* ── dispatch: tools/call ────────────────────── *)
+
+let test_dispatch_tools_call () =
+  let tool = Mcp_types.make_tool ~name:"echo" () in
+  let handler _ctx _name args =
+    let text = match args with
+      | Some (`Assoc fields) ->
+        (match List.assoc_opt "input" fields with
+         | Some (`String s) -> s | _ -> "no input")
+      | _ -> "no args"
+    in
+    Ok (Mcp_types.tool_result_of_text text)
+  in
+  let h = Handler.create ~name:"s" ~version:"1" ()
+    |> Handler.add_tool tool handler in
+  let params = `Assoc [
+    ("name", `String "echo");
+    ("arguments", `Assoc [("input", `String "hello")]);
+  ] in
+  match dispatch_request h "tools/call" ~params () with
+  | Some (Response r) ->
+    (match r.result with
+     | `Assoc fields ->
+       (match List.assoc_opt "content" fields with
+        | Some (`List items) ->
+          Alcotest.(check int) "one content" 1 (List.length items)
+        | _ -> Alcotest.fail "missing content")
+     | _ -> Alcotest.fail "expected assoc")
+  | _ -> Alcotest.fail "expected Response"
+
+let test_dispatch_tools_call_unknown () =
+  let h = Handler.create ~name:"s" ~version:"1" () in
+  let params = `Assoc [("name", `String "nonexistent")] in
+  match dispatch_request h "tools/call" ~params () with
+  | Some (Error _) -> ()
+  | _ -> Alcotest.fail "expected Error for unknown tool"
+
+(* ── dispatch: unknown method ────────────────── *)
+
+let test_dispatch_unknown_method () =
+  let h = Handler.create ~name:"s" ~version:"1" () in
+  match dispatch_request h "totally/unknown" () with
+  | Some (Error e) ->
+    Alcotest.(check int) "method not found code"
+      Error_codes.method_not_found e.error.code
+  | _ -> Alcotest.fail "expected Error"
+
+(* ── dispatch: notification returns None ─────── *)
+
+let test_dispatch_notification_returns_none () =
+  let h = Handler.create ~name:"s" ~version:"1" () in
+  let notif = Jsonrpc.make_notification ~method_:"notifications/initialized" () in
+  let log_ref = ref Logging.Warning in
+  match Handler.dispatch h dummy_ctx log_ref notif with
+  | None -> ()
+  | Some _ -> Alcotest.fail "notification should return None"
+
+(* ── parse_list_field ────────────────────────── *)
+
+let test_parse_list_field_success () =
+  let json = `Assoc [("items", `List [`String "a"; `String "b"])] in
+  let parser = function `String s -> Ok s | _ -> Error "not string" in
+  match Handler.parse_list_field "items" parser json with
+  | Ok items ->
+    Alcotest.(check (list string)) "parsed" ["a"; "b"] items
+  | Error e -> Alcotest.fail e
+
+let test_parse_list_field_missing () =
+  let json = `Assoc [("other", `Int 1)] in
+  let parser = function _ -> Ok () in
+  Alcotest.(check bool) "missing field"
+    true (Result.is_error (Handler.parse_list_field "items" parser json))
+
+let test_parse_list_field_drops_failures () =
+  let json = `Assoc [("items", `List [`String "ok"; `Int 42; `String "also"])] in
+  let parser = function `String s -> Ok s | _ -> Error "not string" in
+  match Handler.parse_list_field "items" parser json with
+  | Ok items ->
+    (* Int 42 silently dropped *)
+    Alcotest.(check (list string)) "filtered" ["ok"; "also"] items
+  | Error e -> Alcotest.fail e
+
+(* ── build_initialize_params ─────────────────── *)
+
+let test_build_init_params () =
+  let params = Handler.build_initialize_params
+    ~has_sampling:true ~has_roots:false ~has_elicitation:true
+    ~client_name:"test" ~client_version:"1.0" in
+  match params with
+  | `Assoc fields ->
+    (match List.assoc_opt "capabilities" fields with
+     | Some (`Assoc caps) ->
+       Alcotest.(check bool) "has sampling" true (List.assoc_opt "sampling" caps <> None);
+       Alcotest.(check bool) "no roots" true (List.assoc_opt "roots" caps = None);
+       Alcotest.(check bool) "has elicitation" true (List.assoc_opt "elicitation" caps <> None)
+     | _ -> Alcotest.fail "missing capabilities")
+  | _ -> Alcotest.fail "expected assoc"
+
+(* ── Suite ────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Handler" [
+    "create", [
+      Alcotest.test_case "basic" `Quick test_create_basic;
+      Alcotest.test_case "with instructions" `Quick test_create_with_instructions;
+      Alcotest.test_case "empty collections" `Quick test_empty_collections;
+    ];
+    "registration", [
+      Alcotest.test_case "add tool" `Quick test_add_tool;
+      Alcotest.test_case "multiple tools" `Quick test_add_multiple_tools;
+      Alcotest.test_case "duplicate replaces" `Quick test_duplicate_tool_replaces;
+      Alcotest.test_case "add resource" `Quick test_add_resource;
+      Alcotest.test_case "add prompt" `Quick test_add_prompt;
+    ];
+    "capabilities", [
+      Alcotest.test_case "empty" `Quick test_capabilities_empty;
+      Alcotest.test_case "with tools" `Quick test_capabilities_with_tools;
+    ];
+    "dispatch", [
+      Alcotest.test_case "initialize" `Quick test_dispatch_initialize;
+      Alcotest.test_case "ping" `Quick test_dispatch_ping;
+      Alcotest.test_case "tools/list" `Quick test_dispatch_tools_list;
+      Alcotest.test_case "tools/call" `Quick test_dispatch_tools_call;
+      Alcotest.test_case "tools/call unknown" `Quick test_dispatch_tools_call_unknown;
+      Alcotest.test_case "unknown method" `Quick test_dispatch_unknown_method;
+      Alcotest.test_case "notification returns None" `Quick test_dispatch_notification_returns_none;
+    ];
+    "helpers", [
+      Alcotest.test_case "parse_list_field" `Quick test_parse_list_field_success;
+      Alcotest.test_case "parse_list_field missing" `Quick test_parse_list_field_missing;
+      Alcotest.test_case "parse_list_field drops" `Quick test_parse_list_field_drops_failures;
+      Alcotest.test_case "build_init_params" `Quick test_build_init_params;
+    ];
+  ]

--- a/test/test_oauth_client.ml
+++ b/test/test_oauth_client.ml
@@ -1,0 +1,210 @@
+(** Unit tests for Oauth_client module.
+
+    Tests pure functions (no network I/O): PKCE, authorization URL,
+    credential store, state parameter, bearer token injection. *)
+
+open Mcp_protocol
+open Mcp_protocol_http
+
+(* ── credential store ─────────────────────────── *)
+
+let test_in_memory_store_empty () =
+  let store = Oauth_client.in_memory_store () in
+  Alcotest.(check (option pass)) "initially empty" None (store.load ())
+
+let test_in_memory_store_save_load () =
+  let store = Oauth_client.in_memory_store () in
+  let creds : Auth.stored_credentials = {
+    client_id = "test-client";
+    token_response = None;
+    granted_scopes = ["read"; "write"];
+  } in
+  store.save creds;
+  match store.load () with
+  | Some loaded ->
+    Alcotest.(check string) "client_id" "test-client" loaded.client_id;
+    Alcotest.(check (list string)) "scopes" ["read"; "write"] loaded.granted_scopes
+  | None -> Alcotest.fail "expected credentials"
+
+let test_in_memory_store_clear () =
+  let store = Oauth_client.in_memory_store () in
+  let creds : Auth.stored_credentials = {
+    client_id = "c"; token_response = None; granted_scopes = [];
+  } in
+  store.save creds;
+  store.clear ();
+  Alcotest.(check (option pass)) "cleared" None (store.load ())
+
+let test_in_memory_store_isolation () =
+  let s1 = Oauth_client.in_memory_store () in
+  let s2 = Oauth_client.in_memory_store () in
+  let creds : Auth.stored_credentials = {
+    client_id = "c1"; token_response = None; granted_scopes = [];
+  } in
+  s1.save creds;
+  Alcotest.(check bool) "s2 is independent" true (s2.load () = None)
+
+(* ── PKCE ─────────────────────────────────────── *)
+
+let test_pkce_generates_pair () =
+  let verifier, challenge = Oauth_client.generate_pkce () in
+  Alcotest.(check bool) "verifier non-empty" true (String.length verifier > 0);
+  Alcotest.(check bool) "challenge non-empty" true (String.length challenge > 0);
+  Alcotest.(check bool) "verifier != challenge" true (verifier <> challenge)
+
+let test_pkce_url_safe () =
+  let verifier, challenge = Oauth_client.generate_pkce () in
+  let is_url_safe s =
+    String.to_seq s |> Seq.for_all (fun c ->
+      (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+      (c >= '0' && c <= '9') || c = '-' || c = '_')
+  in
+  Alcotest.(check bool) "verifier url-safe" true (is_url_safe verifier);
+  Alcotest.(check bool) "challenge url-safe" true (is_url_safe challenge)
+
+let test_pkce_unique () =
+  let v1, _ = Oauth_client.generate_pkce () in
+  let v2, _ = Oauth_client.generate_pkce () in
+  Alcotest.(check bool) "unique verifiers" true (v1 <> v2)
+
+(* ── authorization URL ────────────────────────── *)
+
+let test_build_auth_url_basic () =
+  let url = Oauth_client.build_authorization_url
+    ~authorization_endpoint:"https://auth.example.com/authorize"
+    ~client_id:"my-client"
+    ~redirect_uri:"http://localhost:3000/callback"
+    ~scopes:["read"; "write"]
+    ~state:"random-state"
+    ~code_challenge:"abc123"
+    () in
+  Alcotest.(check bool) "starts with endpoint"
+    true (String.length url > 0
+          && String.sub url 0 (String.length "https://auth.example.com/authorize?")
+             = "https://auth.example.com/authorize?");
+  ignore url;
+  (* Check key parameters are present *)
+  let has s = try let _ = Str.search_forward (Str.regexp_string s) url 0 in true with Not_found -> false in
+  Alcotest.(check bool) "has response_type" true (has "response_type=code");
+  Alcotest.(check bool) "has client_id" true (has "client_id=my-client");
+  Alcotest.(check bool) "has state" true (has "state=random-state");
+  Alcotest.(check bool) "has code_challenge_method" true (has "code_challenge_method=S256")
+
+let test_build_auth_url_with_resource () =
+  let url = Oauth_client.build_authorization_url
+    ~authorization_endpoint:"https://auth.example.com/authorize"
+    ~client_id:"c"
+    ~redirect_uri:"http://localhost/cb"
+    ~scopes:["read"]
+    ~state:"s"
+    ~code_challenge:"ch"
+    ~resource:"https://api.example.com"
+    () in
+  let has s = try let _ = Str.search_forward (Str.regexp_string s) url 0 in true with Not_found -> false in
+  Alcotest.(check bool) "has resource param" true (has "resource=")
+
+let test_build_auth_url_encodes_special_chars () =
+  let url = Oauth_client.build_authorization_url
+    ~authorization_endpoint:"https://auth.example.com/authorize"
+    ~client_id:"client with spaces"
+    ~redirect_uri:"http://localhost/cb?foo=bar"
+    ~scopes:["scope one"; "scope&two"]
+    ~state:"s"
+    ~code_challenge:"ch"
+    () in
+  (* URI-encoded spaces and ampersands *)
+  Alcotest.(check bool) "no raw spaces in query"
+    false (try let _ = Str.search_forward (Str.regexp_string "client with spaces") url 0 in true with Not_found -> false)
+
+(* ── state parameter ──────────────────────────── *)
+
+let test_generate_state_format () =
+  let state = Oauth_client.generate_state () in
+  Alcotest.(check bool) "non-empty" true (String.length state > 0);
+  let is_url_safe s =
+    String.to_seq s |> Seq.for_all (fun c ->
+      (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+      (c >= '0' && c <= '9') || c = '-' || c = '_')
+  in
+  Alcotest.(check bool) "url-safe chars" true (is_url_safe state)
+
+let test_validate_state_exact_match () =
+  Alcotest.(check bool) "exact match"
+    true (Oauth_client.validate_state ~expected:"abc123" ~received:"abc123")
+
+let test_validate_state_mismatch () =
+  Alcotest.(check bool) "content mismatch"
+    false (Oauth_client.validate_state ~expected:"abc" ~received:"xyz")
+
+let test_validate_state_length_differ () =
+  Alcotest.(check bool) "length differ"
+    false (Oauth_client.validate_state ~expected:"short" ~received:"much_longer")
+
+let test_validate_state_empty () =
+  Alcotest.(check bool) "both empty"
+    true (Oauth_client.validate_state ~expected:"" ~received:"")
+
+let test_validate_state_one_empty () =
+  Alcotest.(check bool) "expected empty"
+    false (Oauth_client.validate_state ~expected:"" ~received:"x");
+  Alcotest.(check bool) "received empty"
+    false (Oauth_client.validate_state ~expected:"x" ~received:"")
+
+(* ── bearer token injection ──────────────────── *)
+
+let test_inject_bearer_token () =
+  let headers = Http.Header.init () in
+  let injected = Oauth_client.inject_bearer_token headers ~access_token:"tok123" in
+  match Http.Header.get injected "Authorization" with
+  | Some v -> Alcotest.(check string) "bearer" "Bearer tok123" v
+  | None -> Alcotest.fail "missing Authorization header"
+
+let test_inject_bearer_preserves_existing () =
+  let headers = Http.Header.of_list [("Content-Type", "application/json")] in
+  let injected = Oauth_client.inject_bearer_token headers ~access_token:"t" in
+  Alcotest.(check (option string)) "content-type preserved"
+    (Some "application/json") (Http.Header.get injected "Content-Type");
+  Alcotest.(check (option string)) "auth added"
+    (Some "Bearer t") (Http.Header.get injected "Authorization")
+
+(* ── default_max_response_size ───────────────── *)
+
+let test_default_max_response_size () =
+  Alcotest.(check int) "1MB" (1024 * 1024) Oauth_client.default_max_response_size
+
+(* ── Suite ────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Oauth_client" [
+    "credential_store", [
+      Alcotest.test_case "empty" `Quick test_in_memory_store_empty;
+      Alcotest.test_case "save/load" `Quick test_in_memory_store_save_load;
+      Alcotest.test_case "clear" `Quick test_in_memory_store_clear;
+      Alcotest.test_case "isolation" `Quick test_in_memory_store_isolation;
+    ];
+    "pkce", [
+      Alcotest.test_case "generates pair" `Quick test_pkce_generates_pair;
+      Alcotest.test_case "url-safe" `Quick test_pkce_url_safe;
+      Alcotest.test_case "unique" `Quick test_pkce_unique;
+    ];
+    "authorization_url", [
+      Alcotest.test_case "basic" `Quick test_build_auth_url_basic;
+      Alcotest.test_case "with resource" `Quick test_build_auth_url_with_resource;
+      Alcotest.test_case "encodes special chars" `Quick test_build_auth_url_encodes_special_chars;
+    ];
+    "state_parameter", [
+      Alcotest.test_case "format" `Quick test_generate_state_format;
+      Alcotest.test_case "exact match" `Quick test_validate_state_exact_match;
+      Alcotest.test_case "mismatch" `Quick test_validate_state_mismatch;
+      Alcotest.test_case "length differ" `Quick test_validate_state_length_differ;
+      Alcotest.test_case "both empty" `Quick test_validate_state_empty;
+      Alcotest.test_case "one empty" `Quick test_validate_state_one_empty;
+    ];
+    "bearer_token", [
+      Alcotest.test_case "inject" `Quick test_inject_bearer_token;
+      Alcotest.test_case "preserves existing" `Quick test_inject_bearer_preserves_existing;
+    ];
+    "config", [
+      Alcotest.test_case "max_response_size" `Quick test_default_max_response_size;
+    ];
+  ]


### PR DESCRIPTION
## Summary

테스트 커버리지 확대. 전용 테스트가 없던 2개 핵심 모듈에 단위 테스트 추가.

### test_oauth_client.ml (19 tests)
- credential store: empty, save/load, clear, isolation (2개 store 독립성)
- PKCE: pair 생성, URL-safe 문자, 유니크성
- authorization URL: 기본 파라미터, resource 파라미터, 특수문자 인코딩
- state parameter: 포맷, exact match, mismatch, 길이 불일치, empty 케이스
- bearer token: 주입, 기존 헤더 보존
- config: default_max_response_size 값 검증

### test_handler.ml (21 tests)
- create/accessors: name, version, instructions, empty collections
- registration: tool/resource/prompt 추가, 중복 tool 교체
- capabilities: 빈 상태, tool 있는 상태
- dispatch: initialize, ping, tools/list, tools/call, unknown tool, unknown method, notification
- helpers: parse_list_field (성공/실패/드롭), build_initialize_params

## Test plan
- [x] 40개 신규 테스트 통과
- [x] 전체 490개 테스트, 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)