### PR TITLE
feat: Client.list_resource_templates

### DIFF
--- a/eio/client.ml
+++ b/eio/client.ml
@@ -318,6 +318,16 @@ let unsubscribe_resource t ~uri =
   | Error e -> Error e
   | Ok _ -> Ok ()
 
+let list_resource_templates ?cursor t =
+  let params = match cursor with
+    | Some c -> Some (`Assoc [("cursor", `String c)])
+    | None -> None
+  in
+  match send_request t ~method_:"resources/templates/list" ?params () with
+  | Error e -> Error e
+  | Ok result ->
+    Handler.parse_list_field "resourceTemplates" Mcp_types.resource_template_of_yojson result
+
 (* ── prompts ──────────────────────────────────────── *)
 
 let list_prompts ?cursor t =

--- a/eio/client.mli
+++ b/eio/client.mli
@@ -105,6 +105,10 @@ val subscribe_resource : t -> uri:string -> (unit, string) result
 (** Unsubscribe from change notifications for a resource URI. *)
 val unsubscribe_resource : t -> uri:string -> (unit, string) result
 
+(** List resource templates available on the server. *)
+val list_resource_templates : ?cursor:string -> t ->
+  (Mcp_types.resource_template list, string) result
+
 (** {2 Prompts} *)
 
 (** List prompts available on the server.

--- a/eio/generic_client.ml
+++ b/eio/generic_client.ml
@@ -270,6 +270,16 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     | Error e -> Error e
     | Ok result -> Handler.parse_list_field "contents" Mcp_types.resource_contents_of_yojson result
 
+  let list_resource_templates ?cursor t =
+    let params = match cursor with
+      | Some c -> Some (`Assoc [("cursor", `String c)])
+      | None -> None
+    in
+    match send_request t ~method_:"resources/templates/list" ?params () with
+    | Error e -> Error e
+    | Ok result ->
+      Handler.parse_list_field "resourceTemplates" Mcp_types.resource_template_of_yojson result
+
   (* ── prompts ──────────────────────────────────────── *)
 
   let list_prompts ?cursor t =

--- a/eio/generic_client.mli
+++ b/eio/generic_client.mli
@@ -56,6 +56,8 @@ module Make (T : Mcp_protocol.Transport.S) : sig
     (Mcp_types.resource_contents list, string) result
   val subscribe_resource : t -> uri:string -> (unit, string) result
   val unsubscribe_resource : t -> uri:string -> (unit, string) result
+  val list_resource_templates : ?cursor:string -> t ->
+    (Mcp_types.resource_template list, string) result
 
   (** {2 Prompts} *)
 

--- a/test/test_e2e_memory.ml
+++ b/test/test_e2e_memory.ml
@@ -232,7 +232,14 @@ let test_resource_templates () =
        (Option.is_some result.capabilities.resources)
    | Error e -> Alcotest.fail e);
 
-  (* templates/list via low-level request *)
+  (* templates/list via typed API *)
+  (match Client.list_resource_templates client with
+   | Ok templates ->
+     Alcotest.(check int) "one template" 1 (List.length templates);
+     Alcotest.(check string) "template name" "database" (List.hd templates).name
+   | Error e -> Alcotest.fail ("list_resource_templates: " ^ e));
+
+  (* also verify via low-level request *)
   (match Client.send_request client ~method_:"resources/templates/list" () with
    | Ok result ->
      (match result with


### PR DESCRIPTION
## Summary

- Client + Generic_client에 `list_resource_templates` 추가
- E2E 테스트에서 typed API로 template 목록 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)