### PR TITLE
refactor: API consistency + HttpClient.list_resource_templates

### DIFF
--- a/eio/client.ml
+++ b/eio/client.ml
@@ -323,7 +323,7 @@ let list_resource_templates ?cursor t =
     | Some c -> Some (`Assoc [("cursor", `String c)])
     | None -> None
   in
-  match send_request t ~method_:"resources/templates/list" ?params () with
+  match send_request t ~method_:Notifications.resources_templates_list ?params () with
   | Error e -> Error e
   | Ok result ->
     Handler.parse_list_field "resourceTemplates" Mcp_types.resource_template_of_yojson result

--- a/eio/generic_client.ml
+++ b/eio/generic_client.ml
@@ -275,7 +275,7 @@ module Make (T : Mcp_protocol.Transport.S) = struct
       | Some c -> Some (`Assoc [("cursor", `String c)])
       | None -> None
     in
-    match send_request t ~method_:"resources/templates/list" ?params () with
+    match send_request t ~method_:Notifications.resources_templates_list ?params () with
     | Error e -> Error e
     | Ok result ->
       Handler.parse_list_field "resourceTemplates" Mcp_types.resource_template_of_yojson result

--- a/http/http_client.ml
+++ b/http/http_client.ml
@@ -234,6 +234,16 @@ let unsubscribe_resource t ~uri =
   | Error e -> Error e
   | Ok _ -> Ok ()
 
+let list_resource_templates ?cursor t =
+  let params = match cursor with
+    | Some c -> Some (`Assoc [("cursor", `String c)])
+    | None -> None
+  in
+  match send_request t ~method_:Notifications.resources_templates_list ?params () with
+  | Error e -> Error e
+  | Ok result ->
+    Mcp_protocol_eio.Handler.parse_list_field "resourceTemplates" Mcp_types.resource_template_of_yojson result
+
 (* ── prompts ─────────────────────────────────── *)
 
 let list_prompts ?cursor t =

--- a/http/http_client.mli
+++ b/http/http_client.mli
@@ -93,6 +93,10 @@ val subscribe_resource : t -> uri:string -> (unit, string) result
 (** Unsubscribe from change notifications for a resource URI. *)
 val unsubscribe_resource : t -> uri:string -> (unit, string) result
 
+(** List resource templates available on the server. *)
+val list_resource_templates : ?cursor:string -> t ->
+  (Mcp_types.resource_template list, string) result
+
 (** {2 Prompts} *)
 
 val list_prompts : ?cursor:string -> t -> (Mcp_types.prompt list, string) result


### PR DESCRIPTION
## Summary

- Client/Generic_client: hardcoded string → `Notifications.resources_templates_list`
- HttpClient: `list_resource_templates` 추가 (Client/Generic_client와 API 동일화)
- 33 suites, 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)