### PR TITLE
feat: DNS rebinding protection (MCP 2025-11-25 security)

### DIFF
--- a/http/http_server.ml
+++ b/http/http_server.ml
@@ -50,9 +50,39 @@ let sse_content_type = "text/event-stream"
 let cors_headers = [
   ("Access-Control-Allow-Origin", "*");
   ("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-  ("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id");
+  ("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version");
   ("Access-Control-Expose-Headers", "Mcp-Session-Id");
 ]
+
+(* ── DNS rebinding protection (MCP 2025-11-25) ── *)
+
+(** Localhost origins considered safe.
+    Per spec: servers binding to localhost MUST validate Origin header
+    to prevent DNS rebinding attacks. *)
+let localhost_origins = [
+  "http://localhost"; "https://localhost";
+  "http://127.0.0.1"; "https://127.0.0.1";
+  "http://[::1]"; "https://[::1]";
+]
+
+let is_localhost_origin origin =
+  List.exists (fun prefix ->
+    origin = prefix ||
+    (String.length origin > String.length prefix &&
+     origin.[String.length prefix] = ':' &&
+     String.sub origin 0 (String.length prefix) = prefix)
+  ) localhost_origins
+
+(** Validate Origin header. Returns [Ok ()] if safe, [Error msg] if blocked.
+    - No Origin: allowed (same-origin requests omit it)
+    - Localhost origin (with any port): allowed
+    - Non-localhost origin: blocked *)
+let validate_origin request =
+  match Http.Header.get (Http.Request.headers request) "origin" with
+  | None -> Ok ()
+  | Some origin ->
+    if is_localhost_origin origin then Ok ()
+    else Error (Printf.sprintf "Origin %S is not a localhost origin" origin)
 
 let respond_json ~status body =
   let json_str = Yojson.Safe.to_string body in
@@ -299,6 +329,13 @@ let callback s ?(prefix="/mcp") _conn request body =
     Cohttp_eio.Server.respond_string
       ~status:`Not_found ~body:"Not found" ()
   else
+    (* MCP 2025-11-25: DNS rebinding protection.
+       Validate Origin header before processing any MCP request. *)
+    match validate_origin request with
+    | Error msg ->
+      respond_json ~status:`Forbidden
+        (`Assoc ["error", `String msg])
+    | Ok () ->
     match meth with
     | `POST ->
       (* H5 fix: Parse JSON once here, pass the parsed result to handle_post

--- a/test/test_http_server.ml
+++ b/test/test_http_server.ml
@@ -501,6 +501,52 @@ let test_options_cors env () =
     Alcotest.(check bool) "allow-methods present" true
       (Option.is_some (Http.Header.get hdrs "access-control-allow-methods")))
 
+(* ── DNS rebinding protection ────────────────── *)
+
+let test_dns_rebinding_blocked env () =
+  with_server ~env (fun client port ->
+    Eio.Switch.run @@ fun sw ->
+    (* Request with non-localhost Origin should be blocked *)
+    let headers = Http.Header.of_list [
+      ("Content-Type", "application/json");
+      ("Origin", "https://evil.example.com");
+    ] in
+    let body = Cohttp_eio.Body.of_string (make_initialize_json ()) in
+    let resp, resp_body = Cohttp_eio.Client.call client ~sw ~headers ~body
+      `POST (base_uri port "/mcp") in
+    let status = Http.Status.to_int (Http.Response.status resp) in
+    Alcotest.(check int) "blocked with 403" 403 status;
+    let body_str = read_body resp_body in
+    Alcotest.(check bool) "error mentions origin" true
+      (String.length body_str > 0))
+
+let test_dns_rebinding_localhost_allowed env () =
+  with_server ~env (fun client port ->
+    Eio.Switch.run @@ fun sw ->
+    (* Request with localhost Origin should be allowed *)
+    let headers = Http.Header.of_list [
+      ("Content-Type", "application/json");
+      ("Origin", "http://localhost:3000");
+    ] in
+    let body = Cohttp_eio.Body.of_string (make_initialize_json ()) in
+    let resp, _body = Cohttp_eio.Client.call client ~sw ~headers ~body
+      `POST (base_uri port "/mcp") in
+    let status = Http.Status.to_int (Http.Response.status resp) in
+    Alcotest.(check int) "allowed with 200" 200 status)
+
+let test_dns_rebinding_no_origin_allowed env () =
+  with_server ~env (fun client port ->
+    Eio.Switch.run @@ fun sw ->
+    (* Request without Origin header should be allowed (same-origin) *)
+    let headers = Http.Header.of_list [
+      ("Content-Type", "application/json");
+    ] in
+    let body = Cohttp_eio.Body.of_string (make_initialize_json ()) in
+    let resp, _body = Cohttp_eio.Client.call client ~sw ~headers ~body
+      `POST (base_uri port "/mcp") in
+    let status = Http.Status.to_int (Http.Response.status resp) in
+    Alcotest.(check int) "allowed with 200" 200 status)
+
 (* ── Test suite ──────────────────────────────── *)
 
 let () =
@@ -533,5 +579,10 @@ let () =
       Alcotest.test_case "wrong path" `Quick (test_wrong_path env);
       Alcotest.test_case "method not allowed" `Quick (test_method_not_allowed env);
       Alcotest.test_case "options cors" `Quick (test_options_cors env);
+    ];
+    "dns_rebinding", [
+      Alcotest.test_case "non-localhost blocked" `Quick (test_dns_rebinding_blocked env);
+      Alcotest.test_case "localhost allowed" `Quick (test_dns_rebinding_localhost_allowed env);
+      Alcotest.test_case "no origin allowed" `Quick (test_dns_rebinding_no_origin_allowed env);
     ];
   ]


### PR DESCRIPTION
## Summary

MCP 2025-11-25 spec 보안 요구사항: localhost 바인딩 서버는 Origin 헤더를 검증해야 한다.

- `validate_origin`: localhost 패턴 매칭 (http/https, 127.0.0.1, [::1], any port)
- Non-localhost origin → 403 Forbidden
- No origin (same-origin) → allowed
- 3 new tests (21 total HTTP server tests)

## Test plan
- [x] 33 suites, 0 FAIL
- [x] DNS rebinding: blocked / localhost allowed / no-origin allowed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)