### PR TITLE
refactor: Atomic request ID counter for fiber safety

### DIFF
--- a/eio/generic_server.ml
+++ b/eio/generic_server.ml
@@ -44,14 +44,14 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     handler: Handler.t;
     mutable transport_ref: T.t option;
     mutable log_level: Logging.log_level;
-    mutable next_request_id: int;
+    next_request_id: int Atomic.t;
   }
 
   let create ~name ~version ?instructions () =
     { handler = Handler.create ~name ~version ?instructions ();
       transport_ref = None;
       log_level = Logging.Warning;
-      next_request_id = 1 }
+      next_request_id = Atomic.make 1 }
 
   let add_tool tool handler s =
     { s with handler = Handler.add_tool tool handler s.handler }
@@ -124,9 +124,8 @@ module Make (T : Mcp_protocol.Transport.S) = struct
       with Eio.Time.Timeout ->
         Error (Printf.sprintf "Server request timed out after %.1fs" default_timeout)
 
-  let server_send_request transport next_id_ref ?clock ~method_ ?params () =
-    let id = Jsonrpc.Int !next_id_ref in
-    next_id_ref := !next_id_ref + 1;
+  let server_send_request transport next_id ?clock ~method_ ?params () =
+    let id = Jsonrpc.Int (Atomic.fetch_and_add next_id 1) in
     let msg = Jsonrpc.make_request ~id ~method_ ?params () in
     match T.write transport msg with
     | Error e -> Error e
@@ -134,7 +133,7 @@ module Make (T : Mcp_protocol.Transport.S) = struct
 
   (* ── context builder ─────────────────────────────────── *)
 
-  let make_context transport log_level_ref next_id_ref ?clock () =
+  let make_context transport log_level_ref next_id ?clock () =
     let send_notification ~method_ ~params =
       send_notification_via_transport transport ~method_ ~params
     in
@@ -160,13 +159,13 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     in
     let request_sampling params =
       let json = Sampling.create_message_params_to_yojson params in
-      match server_send_request transport next_id_ref ?clock
+      match server_send_request transport next_id ?clock
               ~method_:Notifications.sampling_create_message ~params:json () with
       | Error e -> Error e
       | Ok result -> Sampling.create_message_result_of_yojson result
     in
     let request_roots_list () =
-      match server_send_request transport next_id_ref ?clock
+      match server_send_request transport next_id ?clock
               ~method_:Notifications.roots_list () with
       | Error e -> Error e
       | Ok result ->
@@ -190,7 +189,7 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     in
     let request_elicitation params =
       let json = Mcp_types.elicitation_params_to_yojson params in
-      match server_send_request transport next_id_ref ?clock
+      match server_send_request transport next_id ?clock
               ~method_:Notifications.elicitation_create ~params:json () with
       | Error e -> Error e
       | Ok result -> Mcp_types.elicitation_result_of_yojson result
@@ -203,8 +202,7 @@ module Make (T : Mcp_protocol.Transport.S) = struct
   let run s ~transport ?clock () =
     s.transport_ref <- Some transport;
     let log_level_ref = ref s.log_level in
-    let next_id_ref = ref s.next_request_id in
-    let ctx = make_context transport log_level_ref next_id_ref ?clock () in
+    let ctx = make_context transport log_level_ref s.next_request_id ?clock () in
     let rec loop () =
       match T.read transport with
       | None -> ()
@@ -227,7 +225,6 @@ module Make (T : Mcp_protocol.Transport.S) = struct
         (try T.close transport
          with _ -> ());
         s.log_level <- !log_level_ref;
-        s.next_request_id <- !next_id_ref;
         s.transport_ref <- None)
 
 end

--- a/eio/server.ml
+++ b/eio/server.ml
@@ -28,14 +28,14 @@ type t = {
   (* Runtime state: set during run, used for send_notification *)
   mutable transport_ref: Stdio_transport.t option;
   mutable log_level: Logging.log_level;
-  mutable next_request_id: int;
+  next_request_id: int Atomic.t;
 }
 
 let create ~name ~version ?instructions () =
   { handler = Handler.create ~name ~version ?instructions ();
     transport_ref = None;
     log_level = Logging.Warning;
-    next_request_id = 1 }
+    next_request_id = Atomic.make 1 }
 
 let add_tool tool handler s =
   { s with handler = Handler.add_tool tool handler s.handler }
@@ -111,9 +111,8 @@ let server_read_response transport ?clock expected_id =
     with Eio.Time.Timeout ->
       Error (Printf.sprintf "Server request timed out after %.1fs" default_timeout)
 
-let server_send_request transport next_id_ref ?clock ~method_ ?params () =
-  let id = Jsonrpc.Int !next_id_ref in
-  next_id_ref := !next_id_ref + 1;
+let server_send_request transport next_id ?clock ~method_ ?params () =
+  let id = Jsonrpc.Int (Atomic.fetch_and_add next_id 1) in
   let msg = Jsonrpc.make_request ~id ~method_ ?params () in
   match Stdio_transport.write transport msg with
   | Error e -> Error e
@@ -121,7 +120,7 @@ let server_send_request transport next_id_ref ?clock ~method_ ?params () =
 
 (* ── context builder ─────────────────────────────────── *)
 
-let make_context transport log_level_ref next_id_ref ?clock () =
+let make_context transport log_level_ref next_id ?clock () =
   let send_notification ~method_ ~params =
     send_notification_via_transport transport ~method_ ~params
   in
@@ -147,13 +146,13 @@ let make_context transport log_level_ref next_id_ref ?clock () =
   in
   let request_sampling params =
     let json = Sampling.create_message_params_to_yojson params in
-    match server_send_request transport next_id_ref ?clock
+    match server_send_request transport next_id ?clock
             ~method_:Notifications.sampling_create_message ~params:json () with
     | Error e -> Error e
     | Ok result -> Sampling.create_message_result_of_yojson result
   in
   let request_roots_list () =
-    match server_send_request transport next_id_ref ?clock
+    match server_send_request transport next_id ?clock
             ~method_:Notifications.roots_list () with
     | Error e -> Error e
     | Ok result ->
@@ -177,7 +176,7 @@ let make_context transport log_level_ref next_id_ref ?clock () =
   in
   let request_elicitation params =
     let json = Mcp_types.elicitation_params_to_yojson params in
-    match server_send_request transport next_id_ref ?clock
+    match server_send_request transport next_id ?clock
             ~method_:Notifications.elicitation_create ~params:json () with
     | Error e -> Error e
     | Ok result -> Mcp_types.elicitation_result_of_yojson result
@@ -191,8 +190,7 @@ let run s ~stdin ~stdout ?clock () =
   let transport = Stdio_transport.create ~stdin ~stdout () in
   s.transport_ref <- Some transport;
   let log_level_ref = ref s.log_level in
-  let next_id_ref = ref s.next_request_id in
-  let ctx = make_context transport log_level_ref next_id_ref ?clock () in
+  let ctx = make_context transport log_level_ref s.next_request_id ?clock () in
   let rec loop () =
     match Stdio_transport.read transport with
     | None -> ()
@@ -215,5 +213,4 @@ let run s ~stdin ~stdout ?clock () =
       (try Stdio_transport.close transport
        with _ -> ());
       s.log_level <- !log_level_ref;
-      s.next_request_id <- !next_id_ref;
       s.transport_ref <- None)


### PR DESCRIPTION
## Summary

Server/Generic_server의 `next_request_id`를 `mutable int` → `int Atomic.t`로 변환.

- `Atomic.fetch_and_add`로 lock-free ID 생성
- `Fun.protect` finally에서 ID 복원 불필요 (Atomic이 자체 관리)
- Multi-fiber 환경에서 ID 충돌 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)