### PR TITLE
fix: second review — Atomic clients, cancellation, URI parsing, log_level race

### DIFF
--- a/eio/client.ml
+++ b/eio/client.ml
@@ -15,7 +15,7 @@ type timeout_fn = { run : 'a. float -> (unit -> 'a) -> 'a }
 
 type t = {
   transport: Stdio_transport.t;
-  mutable next_id: int;
+  next_id: int Atomic.t;
   sampling_handler: sampling_handler option;
   roots_handler: roots_handler option;
   elicitation_handler: elicitation_handler option;
@@ -32,7 +32,7 @@ let create ~stdin ~stdout ?clock () =
   in
   {
     transport = Stdio_transport.create ~stdin ~stdout ();
-    next_id = 1;
+    next_id = Atomic.make 1;
     sampling_handler = None;
     roots_handler = None;
     elicitation_handler = None;
@@ -218,8 +218,7 @@ let send_notification t ~method_ ?params () =
   Stdio_transport.write t.transport msg
 
 let send_request t ~method_ ?params ?(timeout = default_timeout) () =
-  let id = Jsonrpc.Int t.next_id in
-  t.next_id <- t.next_id + 1;
+  let id = Jsonrpc.Int (Atomic.fetch_and_add t.next_id 1) in
   let msg = Jsonrpc.make_request ~id ~method_ ?params () in
   match Stdio_transport.write t.transport msg with
   | Error e -> Error e

--- a/eio/generic_client.ml
+++ b/eio/generic_client.ml
@@ -20,7 +20,7 @@ module Make (T : Mcp_protocol.Transport.S) = struct
 
   type t = {
     transport: T.t;
-    mutable next_id: int;
+    next_id: int Atomic.t;
     sampling_handler: sampling_handler option;
     roots_handler: roots_handler option;
     elicitation_handler: elicitation_handler option;
@@ -37,7 +37,7 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     in
     {
       transport;
-      next_id = 1;
+      next_id = Atomic.make 1;
       sampling_handler = None;
       roots_handler = None;
       elicitation_handler = None;
@@ -163,16 +163,55 @@ module Make (T : Mcp_protocol.Transport.S) = struct
           dispatch_server_request t req;
           loop ()
         | Jsonrpc.Notification notif ->
-          (match t.notification_handler with
-           | Some handler ->
-             (try handler notif.method_ notif.params
-              with
-              | Out_of_memory | Stack_overflow as exn -> raise exn
-              | exn ->
-                Printf.eprintf "Client: notification handler raised: %s\n%!"
-                  (Printexc.to_string exn))
-           | None -> ());
-          loop ()
+          if notif.method_ = Notifications.cancelled then begin
+            (* Check if cancellation targets our in-flight request *)
+            let matches = match notif.params with
+              | Some (`Assoc fields) ->
+                begin match List.assoc_opt "requestId" fields with
+                | Some id_json ->
+                  (match Jsonrpc.id_of_yojson id_json with
+                   | Ok id -> id = expected_id
+                   | Error _ -> false)
+                | None -> false
+                end
+              | _ -> false
+            in
+            if matches then
+              let reason = match notif.params with
+                | Some (`Assoc fields) ->
+                  (match List.assoc_opt "reason" fields with
+                   | Some (`String r) -> Some r
+                   | _ -> None)
+                | _ -> None
+              in
+              Error (Printf.sprintf "Request cancelled%s"
+                (match reason with Some r -> ": " ^ r | None -> ""))
+            else begin
+              (* Cancellation for a different request; pass to handler and continue *)
+              (match t.notification_handler with
+               | Some handler ->
+                 (try handler notif.method_ notif.params
+                  with
+                  | Out_of_memory | Stack_overflow as exn -> raise exn
+                  | exn ->
+                    Printf.eprintf "Client: notification handler raised: %s\n%!"
+                      (Printexc.to_string exn))
+               | None -> ());
+              loop ()
+            end
+          end else begin
+            (* Normal notification handling *)
+            (match t.notification_handler with
+             | Some handler ->
+               (try handler notif.method_ notif.params
+                with
+                | Out_of_memory | Stack_overflow as exn -> raise exn
+                | exn ->
+                  Printf.eprintf "Client: notification handler raised: %s\n%!"
+                    (Printexc.to_string exn))
+             | None -> ());
+            loop ()
+          end
         | _ -> loop ()
         end
     in
@@ -183,8 +222,7 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     T.write t.transport msg
 
   let send_request t ~method_ ?params ?(timeout = default_timeout) () =
-    let id = Jsonrpc.Int t.next_id in
-    t.next_id <- t.next_id + 1;
+    let id = Jsonrpc.Int (Atomic.fetch_and_add t.next_id 1) in
     let msg = Jsonrpc.make_request ~id ~method_ ?params () in
     match T.write t.transport msg with
     | Error e -> Error e

--- a/eio/resilience.ml
+++ b/eio/resilience.ml
@@ -221,5 +221,6 @@ let with_timeout_eio ~clock ~timeout_ms f =
   in
   match result with
   | Ok res -> Ok res
-  | Error _ -> Error "Timeout"
-  | _ -> Error "Unknown error"
+  | Error _ -> TimedOut
+  | CircuitOpen -> CircuitOpen
+  | TimedOut -> TimedOut

--- a/http/http_client.ml
+++ b/http/http_client.ml
@@ -18,7 +18,7 @@ type t = {
   endpoint : Uri.t;
   client : Cohttp_eio.Client.t;
   sw : Eio.Switch.t;
-  mutable next_id : int;
+  next_id : int Atomic.t;
   mutable session_id : string option;
   sampling_handler : sampling_handler option;
   roots_handler : roots_handler option;
@@ -41,7 +41,7 @@ let create ~endpoint ~net ~sw ?clock ?access_token () =
     endpoint = Uri.of_string endpoint;
     client = Tls_helpers.make_client net;
     sw;
-    next_id = 1;
+    next_id = Atomic.make 1;
     session_id = None;
     sampling_handler = None;
     roots_handler = None;
@@ -115,8 +115,7 @@ let do_request t ~method_ ?params () =
   if method_ <> Notifications.initialize && t.session_id = None then
     Error "Not initialized: call initialize first"
   else
-  let id = Jsonrpc.Int t.next_id in
-  t.next_id <- t.next_id + 1;
+  let id = Jsonrpc.Int (Atomic.fetch_and_add t.next_id 1) in
   let msg = Jsonrpc.make_request ~id ~method_ ?params () in
   let json = Jsonrpc.message_to_yojson msg in
   match post_json t json with
@@ -142,7 +141,7 @@ let send_request t ~method_ ?params ?(timeout = default_timeout) () =
   | None -> do_request t ~method_ ?params ()
   | Some tf ->
     (* Capture the request ID before do_request increments next_id *)
-    let request_id = Jsonrpc.Int t.next_id in
+    let request_id = Jsonrpc.Int (Atomic.get t.next_id) in
     begin try
       tf.run timeout (fun () -> do_request t ~method_ ?params ())
     with Eio.Time.Timeout ->

--- a/http/http_server.ml
+++ b/http/http_server.ml
@@ -8,7 +8,7 @@ type t = {
   handler : Mcp_protocol_eio.Handler.t;
   session : Http_session.t;
   broadcaster : Sse.Broadcaster.t;
-  mutable log_level : Logging.log_level;
+  log_level : Logging.log_level Atomic.t;
   mutable sleep : (float -> unit) option;
   auth : Auth_middleware.config option;
 }
@@ -17,7 +17,7 @@ let create ~name ~version ?instructions ?auth () = {
   handler = Mcp_protocol_eio.Handler.create ~name ~version ?instructions ();
   session = Http_session.create ();
   broadcaster = Sse.Broadcaster.create ();
-  log_level = Logging.Warning;
+  log_level = Atomic.make Logging.Warning;
   sleep = None;
   auth;
 }
@@ -56,22 +56,15 @@ let cors_headers = [
 
 (* ── DNS rebinding protection (MCP 2025-11-25) ── *)
 
-(** Localhost origins considered safe.
+(** Check if an origin is a localhost origin using URI parsing.
     Per spec: servers binding to localhost MUST validate Origin header
     to prevent DNS rebinding attacks. *)
-let localhost_origins = [
-  "http://localhost"; "https://localhost";
-  "http://127.0.0.1"; "https://127.0.0.1";
-  "http://[::1]"; "https://[::1]";
-]
-
 let is_localhost_origin origin =
-  List.exists (fun prefix ->
-    origin = prefix ||
-    (String.length origin > String.length prefix &&
-     origin.[String.length prefix] = ':' &&
-     String.sub origin 0 (String.length prefix) = prefix)
-  ) localhost_origins
+  let uri = Uri.of_string origin in
+  match Uri.scheme uri, Uri.host uri, Uri.userinfo uri with
+  | Some ("http" | "https"), Some h, None ->
+    List.mem h ["localhost"; "127.0.0.1"; "::1"; "[::1]"]
+  | _ -> false
 
 (** Validate Origin header. Returns [Ok ()] if safe, [Error msg] if blocked.
     - No Origin: allowed (same-origin requests omit it)
@@ -144,7 +137,7 @@ let make_context s : Mcp_protocol_eio.Handler.context =
     Ok ()
   in
   let send_log level message =
-    if Logging.should_log ~min_level:s.log_level ~msg_level:level then
+    if Logging.should_log ~min_level:(Atomic.get s.log_level) ~msg_level:level then
       let msg = Logging.{ level; logger = None; data = `String message } in
       send_notification
         ~method_:Notifications.logging_message
@@ -203,10 +196,10 @@ let dispatch_jsonrpc s json is_init : Cohttp_eio.Server.response =
       (Jsonrpc.message_to_yojson err)
   | Ok parsed_msg ->
     let ctx = make_context s in
-    let log_level_ref = ref s.log_level in
+    let log_level_ref = ref (Atomic.get s.log_level) in
     let response = Mcp_protocol_eio.Handler.dispatch
       s.handler ctx log_level_ref parsed_msg in
-    s.log_level <- !log_level_ref;
+    Atomic.set s.log_level !log_level_ref;
     if is_init then begin
       (match Http_session.state s.session with
        | Http_session.Uninitialized ->


### PR DESCRIPTION
## Summary

2차 셀프 리뷰에서 발견된 5개 이슈 수정.

1. **Client Atomic next_id**: 3개 client 모두 `int Atomic.t` (서버와 동일)
2. **Generic_client 취소 감지**: `notifications/cancelled` 처리 누락 → Client와 동일 로직 추가
3. **DNS rebinding**: `Uri.of_string` 기반 파싱 (prefix 매칭 → URI 구조 검증)
4. **HTTP log_level**: `mutable` → `Atomic.t` (동시 요청 race 방지)
5. **Resilience catch-all**: `| _ ->` 제거, 모든 `retry_result` constructor 명시

33 suites, 0 FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)