### PR TITLE
fix: log transport close failures during cleanup

### DIFF
--- a/eio/generic_server.ml
+++ b/eio/generic_server.ml
@@ -83,6 +83,14 @@ module Make (T : Mcp_protocol.Transport.S) = struct
   let prompt name ?description ?arguments handler s =
     { s with handler = Handler.prompt name ?description ?arguments handler s.handler }
 
+  let close_transport ~server_name transport =
+    try T.close transport
+    with
+    | Out_of_memory | Stack_overflow as exn -> raise exn
+    | exn ->
+      Printf.eprintf "[%s] Close error: %s\n%!" server_name
+        (Printexc.to_string exn)
+
   (* ── notification sending ────────────────────────────── *)
 
   let send_notification_via_transport transport ~method_ ~params =
@@ -219,11 +227,10 @@ module Make (T : Mcp_protocol.Transport.S) = struct
         | None -> ()
         end;
         loop ()
-    in
-    Fun.protect (fun () -> loop ())
-      ~finally:(fun () ->
-        (try T.close transport
-         with _ -> ());
+  in
+  Fun.protect (fun () -> loop ())
+    ~finally:(fun () ->
+        close_transport ~server_name:(Handler.name s.handler) transport;
         s.log_level <- !log_level_ref;
         s.transport_ref <- None)
 

--- a/eio/server.ml
+++ b/eio/server.ml
@@ -67,6 +67,14 @@ let resource_template ~uri_template name ?description ?mime_type handler s =
 let prompt name ?description ?arguments handler s =
   { s with handler = Handler.prompt name ?description ?arguments handler s.handler }
 
+let close_transport ~server_name transport =
+  try Stdio_transport.close transport
+  with
+  | Out_of_memory | Stack_overflow as exn -> raise exn
+  | exn ->
+    Printf.eprintf "[%s] Close error: %s\n%!" server_name
+      (Printexc.to_string exn)
+
 (* ── notification sending ────────────────────────────── *)
 
 let send_notification_via_transport transport ~method_ ~params =
@@ -210,7 +218,6 @@ let run s ~stdin ~stdout ?clock () =
   in
   Fun.protect (fun () -> loop ())
     ~finally:(fun () ->
-      (try Stdio_transport.close transport
-       with _ -> ());
+      close_transport ~server_name:(Handler.name s.handler) transport;
       s.log_level <- !log_level_ref;
       s.transport_ref <- None)

--- a/test/test_generic_server.ml
+++ b/test/test_generic_server.ml
@@ -7,6 +7,15 @@
 open Mcp_protocol
 module Mt = Mcp_protocol_eio.Memory_transport
 module GS = Mcp_protocol_eio.Generic_server.Make(Mt)
+module Failing_close_transport = struct
+  include Mt
+
+  let close _transport =
+    raise (Failure "boom during close")
+end
+
+module GS_failing_close =
+  Mcp_protocol_eio.Generic_server.Make(Failing_close_transport)
 
 let () = Eio_main.run @@ fun env ->
 
@@ -230,12 +239,26 @@ let test_middleware_composition () =
   Mt.close client_raw
 in
 
+(* ── test: close failures are logged, not re-raised ─── *)
+
+let test_close_failure_is_swallowed () =
+  Eio.Switch.run @@ fun sw ->
+  let client_t, server_t = Mt.create_pair () in
+  let server = GS_failing_close.create ~name:"close-failing" ~version:"1" () in
+  Eio.Fiber.fork ~sw (fun () ->
+    GS_failing_close.run server ~transport:server_t
+      ~clock:(Eio.Stdenv.clock env) ());
+  Mt.close client_t
+in
+
 (* ── test suite ──────────────────────────────── *)
 
 Alcotest.run "Generic_server" [
   "lifecycle", [
     Alcotest.test_case "initialize handshake" `Quick test_initialize;
     Alcotest.test_case "ping" `Quick test_ping;
+    Alcotest.test_case "close failure is swallowed" `Quick
+      test_close_failure_is_swallowed;
   ];
   "tools", [
     Alcotest.test_case "tool call" `Quick test_tool_call;


### PR DESCRIPTION
## Summary
- stop silently swallowing transport close exceptions in stdio and generic server cleanup
- add a regression test for a transport whose `close` raises

## Linked issue
- relates to #54

## Validation
- `dune exec --root . test/test_generic_server.exe`

## Cross-model review
- pending: will add review evidence after PR creation
