### PR TITLE
refactor: dedup pagination, type include_context, _meta on prompt_result

### DIFF
--- a/eio/client.ml
+++ b/eio/client.ml
@@ -266,23 +266,6 @@ let ping t =
   | Error e -> Error e
   | Ok _ -> Ok ()
 
-let collect_pages fetch_page =
-  let module Cursor_set = Set.Make (String) in
-  let rec loop seen cursor acc_rev =
-    match fetch_page cursor with
-    | Error _ as err -> err
-    | Ok (page, next_cursor) ->
-      begin match next_cursor with
-      | Some value when Cursor_set.mem value seen ->
-        Error (Printf.sprintf "Pagination cursor loop detected: %s" value)
-      | Some value ->
-        loop (Cursor_set.add value seen) (Some value)
-          (List.rev_append page acc_rev)
-      | None -> Ok (List.rev_append page acc_rev |> List.rev)
-      end
-  in
-  loop Cursor_set.empty None []
-
 (* ── tools ────────────────────────────────────────── *)
 
 let list_tools ?cursor t =
@@ -297,7 +280,7 @@ let list_tools ?cursor t =
       (Handler.parse_paginated_list_field "tools" Mcp_types.tool_of_yojson result)
 
 let list_tools_all t =
-  collect_pages (fun cursor ->
+  Pagination.collect_pages (fun cursor ->
     let params = Option.map (fun c -> `Assoc [("cursor", `String c)]) cursor in
     match send_request t ~method_:Notifications.tools_list ?params () with
     | Error e -> Error e
@@ -329,7 +312,7 @@ let list_resources ?cursor t =
       (Handler.parse_paginated_list_field "resources" Mcp_types.resource_of_yojson result)
 
 let list_resources_all t =
-  collect_pages (fun cursor ->
+  Pagination.collect_pages (fun cursor ->
     let params = Option.map (fun c -> `Assoc [("cursor", `String c)]) cursor in
     match send_request t ~method_:Notifications.resources_list ?params () with
     | Error e -> Error e
@@ -378,7 +361,7 @@ let list_prompts ?cursor t =
       (Handler.parse_paginated_list_field "prompts" Mcp_types.prompt_of_yojson result)
 
 let list_prompts_all t =
-  collect_pages (fun cursor ->
+  Pagination.collect_pages (fun cursor ->
     let params = Option.map (fun c -> `Assoc [("cursor", `String c)]) cursor in
     match send_request t ~method_:Notifications.prompts_list ?params () with
     | Error e -> Error e

--- a/examples/conformance_server.ml
+++ b/examples/conformance_server.ml
@@ -104,6 +104,7 @@ let () =
                  text = Printf.sprintf "Hello, %s." who;
              };
              }];
+             _meta = None;
            })
     |> Mcp_protocol_http.Http_server.add_completion_handler
          (fun ref_ arg_name arg_value ~context:_ ->

--- a/http/http_client.ml
+++ b/http/http_client.ml
@@ -225,23 +225,6 @@ let send_request t ~method_ ?params ?(timeout = default_timeout) () =
       Error (Printf.sprintf "Request timed out after %.1fs" timeout)
     end
 
-let collect_pages fetch_page =
-  let module Cursor_set = Set.Make (String) in
-  let rec loop seen cursor acc_rev =
-    match fetch_page cursor with
-    | Error _ as err -> err
-    | Ok (page, next_cursor) ->
-      begin match next_cursor with
-      | Some value when Cursor_set.mem value seen ->
-        Error (Printf.sprintf "Pagination cursor loop detected: %s" value)
-      | Some value ->
-        loop (Cursor_set.add value seen) (Some value)
-          (List.rev_append page acc_rev)
-      | None -> Ok (List.rev_append page acc_rev |> List.rev)
-      end
-  in
-  loop Cursor_set.empty None []
-
 (* ── lifecycle ───────────────────────────────── *)
 
 let initialize t ~client_name ~client_version =
@@ -279,7 +262,7 @@ let list_tools ?cursor t =
       (Mcp_protocol_eio.Handler.parse_paginated_list_field "tools" Mcp_types.tool_of_yojson result)
 
 let list_tools_all t =
-  collect_pages (fun cursor ->
+  Pagination.collect_pages (fun cursor ->
     let params = Option.map (fun c -> `Assoc [("cursor", `String c)]) cursor in
     match send_request t ~method_:Notifications.tools_list ?params () with
     | Error e -> Error e
@@ -311,7 +294,7 @@ let list_resources ?cursor t =
       (Mcp_protocol_eio.Handler.parse_paginated_list_field "resources" Mcp_types.resource_of_yojson result)
 
 let list_resources_all t =
-  collect_pages (fun cursor ->
+  Pagination.collect_pages (fun cursor ->
     let params = Option.map (fun c -> `Assoc [("cursor", `String c)]) cursor in
     match send_request t ~method_:Notifications.resources_list ?params () with
     | Error e -> Error e
@@ -361,7 +344,7 @@ let list_prompts ?cursor t =
       (Mcp_protocol_eio.Handler.parse_paginated_list_field "prompts" Mcp_types.prompt_of_yojson result)
 
 let list_prompts_all t =
-  collect_pages (fun cursor ->
+  Pagination.collect_pages (fun cursor ->
     let params = Option.map (fun c -> `Assoc [("cursor", `String c)]) cursor in
     match send_request t ~method_:Notifications.prompts_list ?params () with
     | Error e -> Error e

--- a/lib/dune
+++ b/lib/dune
@@ -4,4 +4,4 @@
  (libraries yojson uri unix)
  (preprocess
   (pps ppx_deriving_yojson))
- (modules mcp_protocol jsonrpc mcp_types mcp_types_completion mcp_types_elicitation mcp_types_tasks error_codes mcp_error http_negotiation version mcp_result session logging sampling notifications transport protocol resources auth result_extra tool_arg))
+ (modules mcp_protocol jsonrpc mcp_types mcp_types_completion mcp_types_elicitation mcp_types_tasks error_codes mcp_error http_negotiation version mcp_result session logging sampling notifications transport protocol resources auth result_extra tool_arg pagination))

--- a/lib/mcp_protocol.ml
+++ b/lib/mcp_protocol.ml
@@ -83,6 +83,9 @@ module Resources = Resources
 (** Result combinators for list traversal *)
 module Result_extra = Result_extra
 
+(** Cursor-based pagination with loop detection *)
+module Pagination = Pagination
+
 (** {1 Convenience Re-exports} *)
 
 (** Protocol version string *)

--- a/lib/mcp_protocol.mli
+++ b/lib/mcp_protocol.mli
@@ -22,6 +22,7 @@ module Auth = Auth
 module Protocol = Protocol
 module Resources = Resources
 module Result_extra = Result_extra
+module Pagination = Pagination
 
 (** {1 Convenience Re-exports} *)
 

--- a/lib/mcp_types.ml
+++ b/lib/mcp_types.ml
@@ -468,6 +468,7 @@ type prompt_message = {
 type prompt_result = {
   description: string option; [@default None]
   messages: prompt_message list;
+  _meta: Yojson.Safe.t option; [@default None] [@key "_meta"]
 }
 [@@deriving yojson]
 

--- a/lib/mcp_types.mli
+++ b/lib/mcp_types.mli
@@ -209,6 +209,7 @@ val prompt_message_of_yojson : Yojson.Safe.t -> (prompt_message, string) result
 type prompt_result = {
   description: string option;
   messages: prompt_message list;
+  _meta: Yojson.Safe.t option;
 }
 
 val prompt_result_to_yojson : prompt_result -> Yojson.Safe.t

--- a/lib/pagination.ml
+++ b/lib/pagination.ml
@@ -1,0 +1,17 @@
+module Cursor_set = Set.Make (String)
+
+let collect_pages fetch_page =
+  let rec loop seen cursor acc_rev =
+    match fetch_page cursor with
+    | Error _ as err -> err
+    | Ok (page, next_cursor) ->
+      begin match next_cursor with
+      | Some value when Cursor_set.mem value seen ->
+        Error (Printf.sprintf "Pagination cursor loop detected: %s" value)
+      | Some value ->
+        loop (Cursor_set.add value seen) (Some value)
+          (List.rev_append page acc_rev)
+      | None -> Ok (List.rev_append page acc_rev |> List.rev)
+      end
+  in
+  loop Cursor_set.empty None []

--- a/lib/pagination.mli
+++ b/lib/pagination.mli
@@ -1,0 +1,8 @@
+(** Cursor-based pagination with loop detection.
+
+    [collect_pages fetch_page] repeatedly calls [fetch_page] with the current
+    cursor (starting from [None]) and accumulates results until no next cursor
+    is returned.  Detects cursor loops and returns [Error] if one is found. *)
+val collect_pages :
+  (string option -> (('a list * string option), string) result) ->
+  ('a list, string) result

--- a/lib/sampling.ml
+++ b/lib/sampling.ml
@@ -189,12 +189,27 @@ let sampling_tool_of_yojson = function
      | _ -> Error "sampling_tool: missing 'name' field")
   | _ -> Error "sampling_tool must be an object"
 
+(** Which context the sampling host should include with the request. *)
+type include_context = None_ | ThisServer | AllServers
+
+let include_context_to_yojson = function
+  | None_ -> `String "none"
+  | ThisServer -> `String "thisServer"
+  | AllServers -> `String "allServers"
+
+let include_context_of_yojson = function
+  | `String "none" -> Ok None_
+  | `String "thisServer" -> Ok ThisServer
+  | `String "allServers" -> Ok AllServers
+  | `String s -> Error (Printf.sprintf "include_context: unknown value %S" s)
+  | _ -> Error "include_context must be a string"
+
 (** Parameters for sampling/createMessage request. *)
 type create_message_params = {
   messages: sampling_message list;
   model_preferences: model_preferences option;
   system_prompt: string option;
-  include_context: string option;  (** "none" | "thisServer" | "allServers" *)
+  include_context: include_context option;
   temperature: float option;
   max_tokens: int;
   stop_sequences: string list option;
@@ -222,7 +237,7 @@ let create_message_params_to_yojson p =
     | None -> fields
   in
   let fields = match p.include_context with
-    | Some ic -> ("includeContext", `String ic) :: fields
+    | Some ic -> ("includeContext", include_context_to_yojson ic) :: fields
     | None -> fields
   in
   let fields = match p.system_prompt with
@@ -268,7 +283,8 @@ let create_message_params_of_yojson = function
          system_prompt = (match List.assoc_opt "systemPrompt" fields with
            | Some (`String s) -> Some s | _ -> None);
          include_context = (match List.assoc_opt "includeContext" fields with
-           | Some (`String s) -> Some s | _ -> None);
+           | Some j -> (match include_context_of_yojson j with Ok ic -> Some ic | Error _ -> None)
+           | None -> None);
          temperature = (match List.assoc_opt "temperature" fields with
            | Some (`Float f) -> Some f | Some (`Int i) -> Some (float_of_int i) | _ -> None);
          max_tokens;

--- a/lib/sampling.mli
+++ b/lib/sampling.mli
@@ -69,11 +69,17 @@ val sampling_tool_of_yojson : Yojson.Safe.t -> (sampling_tool, string) result
 
 (** {2 Create Message} *)
 
+(** Which context the sampling host should include with the request. *)
+type include_context = None_ | ThisServer | AllServers
+
+val include_context_to_yojson : include_context -> Yojson.Safe.t
+val include_context_of_yojson : Yojson.Safe.t -> (include_context, string) result
+
 type create_message_params = {
   messages: sampling_message list;
   model_preferences: model_preferences option;
   system_prompt: string option;
-  include_context: string option;
+  include_context: include_context option;
   temperature: float option;
   max_tokens: int;
   stop_sequences: string list option;

--- a/test/test_e2e_memory.ml
+++ b/test/test_e2e_memory.ml
@@ -125,6 +125,7 @@ let test_prompts () =
           role = User;
           content = PromptText { type_ = "text"; text = "Hello, " ^ name };
         }];
+        _meta = None;
       })
   in
   Eio.Fiber.fork ~sw (fun () ->

--- a/test/test_handler.ml
+++ b/test/test_handler.ml
@@ -85,7 +85,7 @@ let test_add_resource () =
 
 let test_add_prompt () =
   let prompt = Mcp_types.make_prompt ~name:"greet" () in
-  let handler _ctx _name _args = Ok Mcp_types.{ description = None; messages = [] } in
+  let handler _ctx _name _args = Ok Mcp_types.{ description = None; messages = []; _meta = None } in
   let h = Handler.create ~name:"s" ~version:"1" ()
     |> Handler.add_prompt prompt handler in
   Alcotest.(check int) "one prompt" 1 (List.length (Handler.prompts h))

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -65,6 +65,7 @@ let hello_prompt_handler _ctx _name _args =
       role = User;
       content = PromptText { type_ = "text"; text = "Hello!" };
     }];
+    _meta = None;
   }
 
 let make_server () =

--- a/test/test_http_integration.ml
+++ b/test/test_http_integration.ml
@@ -107,6 +107,7 @@ let hello_prompt_handler _ctx _name _args =
       role = User;
       content = PromptText { type_ = "text"; text = "Hello!" };
     }];
+    _meta = None;
   }
 
 let make_server () =

--- a/test/test_integration.ml
+++ b/test/test_integration.ml
@@ -51,7 +51,8 @@ let make_server () =
     let who = match List.assoc_opt "name" args with Some v -> v | None -> "stranger" in
     Ok { Mcp_types.description = None;
          messages = [{ role = Mcp_types.Assistant;
-                       content = Mcp_types.PromptText { type_ = "text"; text = "Hello, " ^ who } }] })
+                       content = Mcp_types.PromptText { type_ = "text"; text = "Hello, " ^ who } }];
+         _meta = None })
 
 (** Run a full server-client test.
     Creates two pipes, runs server in one fiber and client callback in another.

--- a/test/test_sampling.ml
+++ b/test/test_sampling.ml
@@ -100,7 +100,7 @@ let test_create_message_params_roundtrip () =
     ];
     model_preferences = None;
     system_prompt = Some "You are helpful.";
-    include_context = Some "thisServer";
+    include_context = Some Sampling.ThisServer;
     temperature = Some 0.7;
     max_tokens = 1024;
     stop_sequences = Some ["END"];
@@ -114,7 +114,7 @@ let test_create_message_params_roundtrip () =
   | Ok p' ->
     Alcotest.(check int) "messages" 1 (List.length p'.messages);
     Alcotest.(check (option string)) "system_prompt" (Some "You are helpful.") p'.system_prompt;
-    Alcotest.(check (option string)) "include_context" (Some "thisServer") p'.include_context;
+    Alcotest.(check bool) "include_context" true (p'.include_context = Some Sampling.ThisServer);
     Alcotest.(check int) "max_tokens" 1024 p'.max_tokens;
     Alcotest.(check (option (float 0.01))) "temperature" (Some 0.7) p'.temperature
   | Error e -> Alcotest.fail e

--- a/test/test_server.ml
+++ b/test/test_server.ml
@@ -120,6 +120,7 @@ let prompt_handler _ctx _name args =
       role = User;
       content = PromptText { type_ = "text"; text = Printf.sprintf "Hello, %s" who };
     }];
+    _meta = None;
   }
 
 (* ── completion setup ─────────────────────────────────── *)


### PR DESCRIPTION
## Summary
- **`collect_pages` dedup**: Extracted duplicated cursor-based pagination logic from `eio/client.ml` and `http/http_client.ml` into shared `lib/pagination.ml` module
- **`include_context` typed variant**: Replaced `string option` with `include_context = None_ | ThisServer | AllServers` in `sampling.ml` — eliminates stringly-typed values
- **`_meta` on `prompt_result`**: Added `_meta: Yojson.Safe.t option` field for metadata passthrough (was missing vs other result types)

## Changes
- 19 files, +74/-49 lines
- New: `lib/pagination.ml`, `lib/pagination.mli`
- All 522 tests pass

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root .` — 522/522 OK
- [ ] Verify downstream builds (masc-mcp, figma-mcp) after merge

Generated with [Claude Code](https://claude.com/claude-code)