### PR TITLE
feat: add list_X_all pagination helpers to Generic_client

### DIFF
--- a/eio/generic_client.ml
+++ b/eio/generic_client.ml
@@ -261,6 +261,16 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     | Error e -> Error e
     | Ok _ -> Ok ()
 
+  (* ── pagination helper ────────────────────────────── *)
+
+  let list_all_pages t ~method_ ~field ~of_yojson =
+    Pagination.collect_pages (fun cursor ->
+      let params = Option.map (fun c -> `Assoc [("cursor", `String c)]) cursor in
+      match send_request t ~method_ ?params () with
+      | Error e -> Error e
+      | Ok result ->
+        Handler.parse_paginated_list_field field of_yojson result)
+
   (* ── tools ────────────────────────────────────────── *)
 
   let list_tools ?cursor t =
@@ -271,6 +281,10 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     match send_request t ~method_:Notifications.tools_list ?params () with
     | Error e -> Error e
     | Ok result -> Handler.parse_list_field "tools" Mcp_types.tool_of_yojson result
+
+  let list_tools_all t =
+    list_all_pages t ~method_:Notifications.tools_list
+      ~field:"tools" ~of_yojson:Mcp_types.tool_of_yojson
 
   let call_tool t ~name ?arguments () =
     let params_fields = [("name", `String name)] in
@@ -293,6 +307,10 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     match send_request t ~method_:Notifications.resources_list ?params () with
     | Error e -> Error e
     | Ok result -> Handler.parse_list_field "resources" Mcp_types.resource_of_yojson result
+
+  let list_resources_all t =
+    list_all_pages t ~method_:Notifications.resources_list
+      ~field:"resources" ~of_yojson:Mcp_types.resource_of_yojson
 
   let read_resource t ~uri =
     let params = `Assoc [("uri", `String uri)] in
@@ -320,6 +338,10 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     match send_request t ~method_:Notifications.prompts_list ?params () with
     | Error e -> Error e
     | Ok result -> Handler.parse_list_field "prompts" Mcp_types.prompt_of_yojson result
+
+  let list_prompts_all t =
+    list_all_pages t ~method_:Notifications.prompts_list
+      ~field:"prompts" ~of_yojson:Mcp_types.prompt_of_yojson
 
   let get_prompt t ~name ?arguments () =
     let params_fields = [("name", `String name)] in
@@ -370,6 +392,10 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     match send_request t ~method_:Notifications.tasks_list ?params () with
     | Error e -> Error e
     | Ok result -> Handler.parse_list_field "tasks" Mcp_types.task_of_yojson result
+
+  let list_tasks_all t =
+    list_all_pages t ~method_:Notifications.tasks_list
+      ~field:"tasks" ~of_yojson:Mcp_types.task_of_yojson
 
   let cancel_task t ~task_id =
     let params = `Assoc [("taskId", `String task_id)] in

--- a/eio/generic_client.mli
+++ b/eio/generic_client.mli
@@ -46,12 +46,14 @@ module Make (T : Mcp_protocol.Transport.S) : sig
   (** {2 Tools} *)
 
   val list_tools : ?cursor:string -> t -> (Mcp_types.tool list, string) result
+  val list_tools_all : t -> (Mcp_types.tool list, string) result
   val call_tool : t -> name:string -> ?arguments:Yojson.Safe.t -> unit ->
     (Mcp_types.tool_result, string) result
 
   (** {2 Resources} *)
 
   val list_resources : ?cursor:string -> t -> (Mcp_types.resource list, string) result
+  val list_resources_all : t -> (Mcp_types.resource list, string) result
   val read_resource : t -> uri:string ->
     (Mcp_types.resource_contents list, string) result
   val subscribe_resource : t -> uri:string -> (unit, string) result
@@ -62,6 +64,7 @@ module Make (T : Mcp_protocol.Transport.S) : sig
   (** {2 Prompts} *)
 
   val list_prompts : ?cursor:string -> t -> (Mcp_types.prompt list, string) result
+  val list_prompts_all : t -> (Mcp_types.prompt list, string) result
   val get_prompt : t -> name:string -> ?arguments:(string * string) list -> unit ->
     (Mcp_types.prompt_result, string) result
 
@@ -70,6 +73,7 @@ module Make (T : Mcp_protocol.Transport.S) : sig
   val get_task : t -> task_id:string -> (Mcp_types.task, string) result
   val get_task_result : t -> task_id:string -> (Yojson.Safe.t, string) result
   val list_tasks : ?cursor:string -> t -> (Mcp_types.task list, string) result
+  val list_tasks_all : t -> (Mcp_types.task list, string) result
   val cancel_task : t -> task_id:string -> (Mcp_types.task, string) result
 
   (** {2 Low-level} *)


### PR DESCRIPTION
## Summary
Add `list_tools_all`, `list_resources_all`, `list_prompts_all`, `list_tasks_all` to `Generic_client.Make(T)`.

These were available in `Client` (stdio) and `Http_client` but missing from the generic functor client. Uses `Pagination.collect_pages` for cursor-based pagination with loop detection.

+30 lines, 565/565 tests pass.

Generated with [Claude Code](https://claude.com/claude-code)