### PR TITLE
fix: remove Unix.sleepf fallback + narrow jsonrpc exception catch

### DIFF
--- a/eio/time_compat.ml
+++ b/eio/time_compat.ml
@@ -49,20 +49,19 @@ let now_ms () =
 let now_us () =
   Int64.of_float (now () *. 1_000_000.0)
 
-(** Sleep for given duration (Eio-native when available)
+(** Sleep for given duration using Eio clock.
 
-    When clock is not set, logs a warning and uses Unix.sleepf.
-    Callers in Eio contexts MUST ensure [set_clock] was called first,
-    otherwise Unix.sleepf blocks the entire Eio domain (all fibers freeze).
+    Raises [Failure] if no Eio clock is set. Previous versions fell back to
+    [Unix.sleepf] which blocks the entire Eio domain (all fibers freeze).
+    Call [set_clock] at startup to avoid this.
 
-    @param seconds Duration to sleep *)
+    @param seconds Duration to sleep
+    @raise Failure if no Eio clock has been set via [set_clock] *)
 let sleep seconds =
   match !global_clock with
   | Some clock -> Eio.Time.sleep clock seconds
   | None ->
-      if seconds > 0.01 then
-        Printf.eprintf "[WARN] [Time_compat] sleep %.3fs with Unix.sleepf (no Eio clock set)\n%!" seconds;
-      Unix.sleepf seconds
+    failwith "Time_compat.sleep: no Eio clock set. Call Time_compat.set_clock at startup."
 
 (** Measure execution time of a function
 

--- a/eio/time_compat.mli
+++ b/eio/time_compat.mli
@@ -37,8 +37,8 @@ val now_us : unit -> Int64.t
 (** Current timestamp in microseconds (Int64). *)
 
 val sleep : float -> unit
-(** Sleep for the given duration in seconds. Uses [Eio.Time.sleep] when clock
-    is set, [Unix.sleepf] otherwise (with a warning for durations > 10ms). *)
+(** Sleep for the given duration in seconds. Uses [Eio.Time.sleep].
+    @raise Failure if no Eio clock has been set via {!set_clock}. *)
 
 val timed : (unit -> 'a) -> 'a * float
 (** [timed f] runs [f ()] and returns [(result, duration_seconds)]. *)

--- a/lib/jsonrpc.ml
+++ b/lib/jsonrpc.ml
@@ -142,8 +142,12 @@ let message_of_yojson json =
   | Yojson.Json_error msg ->
     Error (Printf.sprintf "JSON parse error: %s" msg)
   | Out_of_memory | Stack_overflow as exn -> raise exn
-  | exn ->
-    Error (Printf.sprintf "Unexpected parse error: %s" (Printexc.to_string exn))
+  | Not_found ->
+    Error "JSON-RPC parse error: missing required field"
+  | Invalid_argument msg ->
+    Error (Printf.sprintf "JSON-RPC parse error: %s" msg)
+  | Failure msg ->
+    Error (Printf.sprintf "JSON-RPC parse error: %s" msg)
 
 (** Convert a JSON-RPC message to JSON *)
 let message_to_yojson = function


### PR DESCRIPTION
## Summary
- **time_compat.ml**: `sleep` now raises `Failure` if no Eio clock set (was: silent `Unix.sleepf` blocking entire Eio domain). `now()` fallback retained (non-blocking).
- **jsonrpc.ml**: Replace catch-all `| exn ->` with specific `Not_found`, `Invalid_argument`, `Failure` handlers. Other exceptions propagate.

565/565 tests pass.

Closes #56, partially addresses #54.

Generated with [Claude Code](https://claude.com/claude-code)