### PR TITLE
[codex] Simplify mcp-protocol-sdk CI around OCaml 5.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ocaml-compiler: ['5.2', '5.3']
-        include:
-          - os: ubuntu-latest
-            ocaml-compiler: '5.4'
+        ocaml-compiler: ['5.4.1']
 
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +49,7 @@ jobs:
       - name: Set up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: '5.4'
+          ocaml-compiler: '5.4.1'
 
       - name: Install dependencies
         run: opam install . --deps-only


### PR DESCRIPTION
## What changed
- reduce CI matrix to the 5.4.1 rollout target
- align lint job with OCaml 5.4.1

## Why
- make 5.4.1 the primary validation target for the current rollout

## Validation
- local: `dune build` on OCaml 5.4.1
- local: `dune runtest` on OCaml 5.4.1