### PR TITLE
fix(http): reject q=0 media types per RFC 7231 (#80)

### DIFF
--- a/lib/http_negotiation.ml
+++ b/lib/http_negotiation.ml
@@ -74,15 +74,16 @@ let media_type_matches ~pattern ~actual =
 let accepts_sse header =
   let media_types = parse_accept_header header in
   List.exists (fun mt ->
-    mt.type_ = "text" && mt.subtype = "event-stream"
+    mt.quality > 0.0 && mt.type_ = "text" && mt.subtype = "event-stream"
   ) media_types
 
 (** Check if client accepts JSON *)
 let accepts_json header =
   let media_types = parse_accept_header header in
   List.exists (fun mt ->
-    (mt.type_ = "application" && mt.subtype = "json") ||
-    (mt.type_ = "*" && mt.subtype = "*")
+    mt.quality > 0.0 &&
+    ((mt.type_ = "application" && mt.subtype = "json") ||
+     (mt.type_ = "*" && mt.subtype = "*"))
   ) media_types
 
 (** Check if client accepts streamable MCP (JSON or SSE) *)

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -82,7 +82,11 @@ let test_accepts_sse () =
   Alcotest.(check bool) "sse header"
     true (Http_negotiation.accepts_sse "text/event-stream, application/json");
   Alcotest.(check bool) "no sse"
-    false (Http_negotiation.accepts_sse "application/json")
+    false (Http_negotiation.accepts_sse "application/json");
+  Alcotest.(check bool) "sse q=0 rejected (RFC 7231)"
+    false (Http_negotiation.accepts_sse "text/event-stream;q=0");
+  Alcotest.(check bool) "sse q=0.0 rejected"
+    false (Http_negotiation.accepts_sse "text/event-stream;q=0.0")
 
 let test_accepts_json () =
   Alcotest.(check bool) "json header"
@@ -90,7 +94,11 @@ let test_accepts_json () =
   Alcotest.(check bool) "wildcard accepts json"
     true (Http_negotiation.accepts_json "*/*");
   Alcotest.(check bool) "sse only"
-    false (Http_negotiation.accepts_json "text/event-stream")
+    false (Http_negotiation.accepts_json "text/event-stream");
+  Alcotest.(check bool) "json q=0 rejected (RFC 7231)"
+    false (Http_negotiation.accepts_json "application/json;q=0");
+  Alcotest.(check bool) "wildcard q=0 rejected"
+    false (Http_negotiation.accepts_json "*/*;q=0")
 
 let test_accepts_streamable_mcp () =
   Alcotest.(check bool) "json + sse"


### PR DESCRIPTION
## Summary
- `accepts_sse` and `accepts_json` now check `mt.quality > 0.0` before matching
- `accepts_streamable_mcp` already had this check — now all three are consistent
- Per RFC 7231 Section 5.3.1, `q=0` means "not acceptable"

Fixes #80

## Test plan
- [x] 21 tests pass including 4 new q=0 rejection cases
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)