### PR TITLE
refactor: centralize retry policy, buffer limits, and timeout defaults

### DIFF
--- a/eio/client.ml
+++ b/eio/client.ml
@@ -23,7 +23,7 @@ type t = {
   timeout_fn: timeout_fn option;
 }
 
-let default_timeout = 60.0
+let default_timeout = Mcp_protocol.Defaults.default_timeout
 
 let create ~stdin ~stdout ?clock () =
   let timeout_fn = match clock with

--- a/eio/generic_client.ml
+++ b/eio/generic_client.ml
@@ -28,7 +28,7 @@ module Make (T : Mcp_protocol.Transport.S) = struct
     timeout_fn: timeout_fn option;
   }
 
-  let default_timeout = 60.0
+  let default_timeout = Mcp_protocol.Defaults.default_timeout
 
   let create ~transport ?clock () =
     let timeout_fn = match clock with

--- a/eio/generic_server.ml
+++ b/eio/generic_server.ml
@@ -104,7 +104,7 @@ module Make (T : Mcp_protocol.Transport.S) = struct
 
   (* ── server request sending ──────────────────────────── *)
 
-  let default_timeout = 60.0
+  let default_timeout = Mcp_protocol.Defaults.default_timeout
 
   let server_read_response transport ?clock expected_id =
     let do_read () =

--- a/eio/resilience.ml
+++ b/eio/resilience.ml
@@ -24,12 +24,36 @@ type retry_policy = {
   jitter: bool;
 }
 
+(** Read an environment variable as int, returning [default] on missing or
+    unparseable values. *)
+let env_int name default =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some s -> (match int_of_string_opt s with Some v -> v | None -> default)
+
+(** Read an environment variable as float, returning [default] on missing or
+    unparseable values. *)
+let env_float name default =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some s -> (match float_of_string_opt s with Some v -> v | None -> default)
+
+(** Read an environment variable as bool ("true"/"1" -> true, else default). *)
+let env_bool name default =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some s ->
+    let lower = String.lowercase_ascii s in
+    if lower = "true" || lower = "1" then true
+    else if lower = "false" || lower = "0" then false
+    else default
+
 let default_policy = {
-  max_attempts = 3;
-  initial_delay_ms = 100;
-  max_delay_ms = 10000;
-  backoff_multiplier = 2.0;
-  jitter = true;
+  max_attempts = env_int "MCP_RETRY_MAX_ATTEMPTS" 3;
+  initial_delay_ms = env_int "MCP_RETRY_INITIAL_DELAY_MS" 100;
+  max_delay_ms = env_int "MCP_RETRY_MAX_DELAY_MS" 10000;
+  backoff_multiplier = env_float "MCP_RETRY_BACKOFF_MULTIPLIER" 2.0;
+  jitter = env_bool "MCP_RETRY_JITTER" true;
 }
 
 (* ============================================ *)

--- a/http/dune
+++ b/http/dune
@@ -2,6 +2,6 @@
  (name mcp_protocol_http)
  (public_name mcp_protocol.http)
  (libraries mcp_protocol mcp_protocol.eio eio eio.unix yojson cohttp-eio uri base64 digestif mirage-crypto-rng mirage-crypto-rng.unix tls tls-eio ca-certs)
- (modules sse sse_flow http_session http_server http_client auth_middleware oauth_client tls_helpers)
+ (modules sse sse_flow http_session http_server http_client auth_middleware oauth_client tls_helpers http_limits)
  (ocamlopt_flags (:standard -w -69))
  (ocamlc_flags (:standard -w -69)))

--- a/http/http_client.ml
+++ b/http/http_client.ml
@@ -29,7 +29,7 @@ type t = {
   headers : (string * string) list;
 }
 
-let default_timeout = 60.0
+let default_timeout = Mcp_protocol.Defaults.default_timeout
 
 (* ── construction ────────────────────────────── *)
 
@@ -151,7 +151,7 @@ let post_json t body_json =
    | None -> ());
   let status = Http.Response.status resp in
   let body_str =
-    Eio.Buf_read.of_flow ~max_size:(10 * 1024 * 1024) resp_body
+    Eio.Buf_read.of_flow ~max_size:Http_limits.default_max_response_size resp_body
     |> Eio.Buf_read.take_all
   in
   (status, resp_headers, body_str)
@@ -405,7 +405,7 @@ let close t =
           ~headers t.endpoint
       in
       let _body_str =
-        Eio.Buf_read.of_flow ~max_size:(1024 * 1024) body
+        Eio.Buf_read.of_flow ~max_size:Http_limits.oauth_max_response_size body
         |> Eio.Buf_read.take_all
       in
       Http.Response.status resp

--- a/http/http_limits.ml
+++ b/http/http_limits.ml
@@ -1,0 +1,16 @@
+(** Shared HTTP buffer size limits.
+
+    Centralizes max body sizes for HTTP request/response parsing.
+    All HTTP-layer modules reference these instead of hardcoding values. *)
+
+(** Maximum response body size for general HTTP responses (10 MB). *)
+let default_max_response_size = 10 * 1024 * 1024
+
+(** Maximum request body size for incoming HTTP requests (10 MB). *)
+let default_max_request_size = 10 * 1024 * 1024
+
+(** Maximum response body size for OAuth HTTP responses (1 MB).
+    Intentionally smaller than the general limit: OAuth token/discovery
+    responses are small JSON payloads and a 1 MB cap provides defense
+    against unexpected large responses from authorization servers. *)
+let oauth_max_response_size = 1024 * 1024

--- a/http/http_limits.mli
+++ b/http/http_limits.mli
@@ -1,0 +1,16 @@
+(** Shared HTTP buffer size limits.
+
+    Centralizes max body sizes for HTTP request/response parsing.
+    All HTTP-layer modules reference these instead of hardcoding values. *)
+
+val default_max_response_size : int
+(** Maximum response body size for general HTTP responses (10 MB). *)
+
+val default_max_request_size : int
+(** Maximum request body size for incoming HTTP requests (10 MB). *)
+
+val oauth_max_response_size : int
+(** Maximum response body size for OAuth HTTP responses (1 MB).
+    Intentionally smaller than the general limit: OAuth token/discovery
+    responses are small JSON payloads, so a tighter cap provides defense
+    against unexpected large responses from authorization servers. *)

--- a/http/http_server.ml
+++ b/http/http_server.ml
@@ -542,7 +542,7 @@ let callback s ?(prefix="/mcp") _conn request body =
          to avoid double-parsing (previously parsed for is_init check in
          callback AND again in handle_post). *)
       begin match
-        Eio.Buf_read.of_flow ~max_size:(10 * 1024 * 1024) body
+        Eio.Buf_read.of_flow ~max_size:Http_limits.default_max_request_size body
         |> Eio.Buf_read.take_all
       with
       | body_str ->

--- a/http/oauth_client.ml
+++ b/http/oauth_client.ml
@@ -74,10 +74,7 @@ let build_authorization_url
 
 (* ── constants ─────────────────────────────── *)
 
-(** L1 fix: Maximum response body size for OAuth HTTP responses (1 MB).
-    Extracted from 3 hardcoded occurrences. Override by passing ~max_response_size
-    to individual functions if needed in the future. *)
-let default_max_response_size = 1024 * 1024
+let default_max_response_size = Http_limits.oauth_max_response_size
 
 (* ── HTTP helpers ───────────────────────────── *)
 

--- a/lib/defaults.ml
+++ b/lib/defaults.ml
@@ -1,0 +1,3 @@
+(** SDK-wide default values shared across transport implementations. *)
+
+let default_timeout = 60.0

--- a/lib/defaults.mli
+++ b/lib/defaults.mli
@@ -1,0 +1,5 @@
+(** SDK-wide default values shared across transport implementations. *)
+
+val default_timeout : float
+(** Default request timeout in seconds (60.0). Used by stdio, generic, and
+    HTTP client/server implementations. *)

--- a/lib/dune
+++ b/lib/dune
@@ -4,4 +4,4 @@
  (libraries yojson uri unix)
  (preprocess
   (pps ppx_deriving_yojson))
- (modules mcp_protocol jsonrpc mcp_types mcp_types_completion mcp_types_elicitation mcp_types_tasks error_codes mcp_error http_negotiation version mcp_result session logging sampling notifications transport protocol resources auth result_extra tool_arg pagination))
+ (modules mcp_protocol jsonrpc mcp_types mcp_types_completion mcp_types_elicitation mcp_types_tasks error_codes mcp_error http_negotiation version mcp_result session logging sampling notifications transport protocol resources auth result_extra tool_arg pagination defaults))

--- a/lib/mcp_protocol.ml
+++ b/lib/mcp_protocol.ml
@@ -86,6 +86,9 @@ module Result_extra = Result_extra
 (** Cursor-based pagination with loop detection *)
 module Pagination = Pagination
 
+(** SDK-wide default values *)
+module Defaults = Defaults
+
 (** {1 Convenience Re-exports} *)
 
 (** Protocol version string *)

--- a/lib/mcp_protocol.mli
+++ b/lib/mcp_protocol.mli
@@ -23,6 +23,7 @@ module Protocol = Protocol
 module Resources = Resources
 module Result_extra = Result_extra
 module Pagination = Pagination
+module Defaults = Defaults
 
 (** {1 Convenience Re-exports} *)
 


### PR DESCRIPTION
## Summary

- Retry policy: env var 지원 추가 (`MCP_RETRY_MAX_ATTEMPTS` 등 5개)
- Buffer 크기: `Http_limits` 모듈로 중앙화 (10MB response/request, 1MB OAuth)
- Timeout: `Defaults.default_timeout` 한 곳에 정의, 4개 모듈에서 참조

## Motivation

Cross-repo 감사 P2: retry policy가 코드 변경 없이 튜닝 불가, buffer 크기가 4곳에서 불일치, timeout이 4곳에 중복 정의.

## Test plan
- [x] `dune build` + `dune test` 통과
- [ ] CI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)