### PR TITLE
fix(time_compat): improve uninitialized clock error and add check_initialized

### DIFF
--- a/eio/time_compat.ml
+++ b/eio/time_compat.ml
@@ -61,7 +61,14 @@ let sleep seconds =
   match !global_clock with
   | Some clock -> Eio.Time.sleep clock seconds
   | None ->
-    failwith "Time_compat.sleep: no Eio clock set. Call Time_compat.set_clock at startup."
+    failwith "Time_compat: clock not initialized. Call Time_compat.set_clock during Eio.main before using sleep."
+
+(** Check that the clock has been initialized. Call at startup to catch
+    missing [set_clock] early instead of at the first [sleep] call. *)
+let check_initialized () : (unit, string) result =
+  match !global_clock with
+  | Some _ -> Ok ()
+  | None -> Error "Time_compat: clock not initialized. Call set_clock during Eio.main."
 
 (** Measure execution time of a function
 

--- a/eio/time_compat.mli
+++ b/eio/time_compat.mli
@@ -40,6 +40,10 @@ val sleep : float -> unit
 (** Sleep for the given duration in seconds. Uses [Eio.Time.sleep].
     @raise Failure if no Eio clock has been set via {!set_clock}. *)
 
+val check_initialized : unit -> (unit, string) result
+(** Check that the clock has been initialized. Call at startup to catch
+    missing {!set_clock} early instead of at the first {!sleep} call. *)
+
 val timed : (unit -> 'a) -> 'a * float
 (** [timed f] runs [f ()] and returns [(result, duration_seconds)]. *)
 


### PR DESCRIPTION
## Summary
Better error message + `check_initialized()` for early startup validation. Closes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)