### PR TITLE
refactor: tighten protocol decoding boundaries

### DIFF
--- a/eio/client.ml
+++ b/eio/client.ml
@@ -1,414 +1,44 @@
 (** MCP Client over Eio stdio transport. *)
 
-open Mcp_protocol
+module Base = Generic_client.Make (Stdio_transport)
 
-type sampling_handler =
-  Sampling.create_message_params -> (Sampling.create_message_result, string) result
-type roots_handler =
-  unit -> (Mcp_types.root list, string) result
-type elicitation_handler =
-  Mcp_types.elicitation_params -> (Mcp_types.elicitation_result, string) result
-type notification_handler =
-  string -> Yojson.Safe.t option -> unit
+type t = Base.t
 
-type timeout_fn = { run : 'a. float -> (unit -> 'a) -> 'a }
-
-type t = {
-  transport: Stdio_transport.t;
-  next_id: int Atomic.t;
-  sampling_handler: sampling_handler option;
-  roots_handler: roots_handler option;
-  elicitation_handler: elicitation_handler option;
-  notification_handler: notification_handler option;
-  timeout_fn: timeout_fn option;
-}
-
-let default_timeout = Mcp_protocol.Defaults.default_timeout
+type sampling_handler = Base.sampling_handler
+type roots_handler = Base.roots_handler
+type elicitation_handler = Base.elicitation_handler
+type notification_handler = Base.notification_handler
 
 let create ~stdin ~stdout ?clock () =
-  let timeout_fn = match clock with
-    | Some c -> Some { run = fun d f -> Eio.Time.with_timeout_exn c d f }
-    | None -> None
-  in
-  {
-    transport = Stdio_transport.create ~stdin ~stdout ();
-    next_id = Atomic.make 1;
-    sampling_handler = None;
-    roots_handler = None;
-    elicitation_handler = None;
-    notification_handler = None;
-    timeout_fn;
-  }
+  let transport = Stdio_transport.create ~stdin ~stdout () in
+  Base.create ~transport ?clock ()
 
-let on_sampling handler t = { t with sampling_handler = Some handler }
-let on_roots_list handler t = { t with roots_handler = Some handler }
-let on_elicitation handler t = { t with elicitation_handler = Some handler }
-let on_notification handler t = { t with notification_handler = Some handler }
+let on_sampling = Base.on_sampling
+let on_roots_list = Base.on_roots_list
+let on_elicitation = Base.on_elicitation
+let on_notification = Base.on_notification
 
-(* ── server request dispatch ─────────────────────── *)
+let initialize = Base.initialize
+let ping = Base.ping
 
-let send_response t ~id ~result =
-  let msg = Jsonrpc.make_response ~id ~result in
-  match Stdio_transport.write t.transport msg with
-  | Ok () -> ()
-  | Error e -> Printf.eprintf "Client: failed to send response: %s\n%!" e
+let list_tools = Base.list_tools
+let list_tools_all = Base.list_tools_all
+let call_tool = Base.call_tool
 
-let send_error_response t ~id ~code ~message =
-  let msg = Jsonrpc.make_error ~id ~code ~message () in
-  match Stdio_transport.write t.transport msg with
-  | Ok () -> ()
-  | Error e -> Printf.eprintf "Client: failed to send error response: %s\n%!" e
+let list_resources = Base.list_resources
+let list_resources_all = Base.list_resources_all
+let read_resource = Base.read_resource
+let subscribe_resource = Base.subscribe_resource
+let unsubscribe_resource = Base.unsubscribe_resource
+let list_resource_templates = Base.list_resource_templates
 
-let dispatch_server_request t (req : Jsonrpc.request) =
-  match req.method_ with
-  | m when m = Notifications.sampling_create_message ->
-    begin match t.sampling_handler with
-    | None ->
-      send_error_response t ~id:req.id
-        ~code:Error_codes.method_not_found
-        ~message:"No sampling handler registered"
-    | Some handler ->
-      begin match req.params with
-      | Some json ->
-        begin match Sampling.create_message_params_of_yojson json with
-        | Ok params ->
-          begin match handler params with
-          | Ok result ->
-            send_response t ~id:req.id
-              ~result:(Sampling.create_message_result_to_yojson result)
-          | Error msg ->
-            send_error_response t ~id:req.id
-              ~code:Error_codes.internal_error ~message:msg
-          end
-        | Error msg ->
-          send_error_response t ~id:req.id
-            ~code:Error_codes.invalid_params ~message:msg
-        end
-      | None ->
-        send_error_response t ~id:req.id
-          ~code:Error_codes.invalid_params
-          ~message:"Missing params for sampling/createMessage"
-      end
-    end
-  | m when m = Notifications.roots_list ->
-    begin match t.roots_handler with
-    | None ->
-      send_error_response t ~id:req.id
-        ~code:Error_codes.method_not_found
-        ~message:"No roots handler registered"
-    | Some handler ->
-      begin match handler () with
-      | Ok roots ->
-        let roots_json = List.map Mcp_types.root_to_yojson roots in
-        send_response t ~id:req.id
-          ~result:(`Assoc [("roots", `List roots_json)])
-      | Error msg ->
-        send_error_response t ~id:req.id
-          ~code:Error_codes.internal_error ~message:msg
-      end
-    end
-  | m when m = Notifications.elicitation_create ->
-    begin match t.elicitation_handler with
-    | None ->
-      send_error_response t ~id:req.id
-        ~code:Error_codes.method_not_found
-        ~message:"No elicitation handler registered"
-    | Some handler ->
-      begin match req.params with
-      | Some json ->
-        begin match Mcp_types.elicitation_params_of_yojson json with
-        | Ok params ->
-          begin match handler params with
-          | Ok result ->
-            send_response t ~id:req.id
-              ~result:(Mcp_types.elicitation_result_to_yojson result)
-          | Error msg ->
-            send_error_response t ~id:req.id
-              ~code:Error_codes.internal_error ~message:msg
-          end
-        | Error msg ->
-          send_error_response t ~id:req.id
-            ~code:Error_codes.invalid_params ~message:msg
-        end
-      | None ->
-        send_error_response t ~id:req.id
-          ~code:Error_codes.invalid_params
-          ~message:"Missing params for elicitation/create"
-      end
-    end
-  | _ ->
-    send_error_response t ~id:req.id
-      ~code:Error_codes.method_not_found
-      ~message:(Printf.sprintf "Unknown server request: %s" req.method_)
+let list_prompts = Base.list_prompts
+let list_prompts_all = Base.list_prompts_all
+let get_prompt = Base.get_prompt
 
-(* ── request/response ─────────────────────────────── *)
+let get_task = Base.get_task
+let get_task_result = Base.get_task_result
+let list_tasks = Base.list_tasks
+let cancel_task = Base.cancel_task
 
-let read_response t expected_id =
-  let rec loop () =
-    match Stdio_transport.read t.transport with
-    | None -> Error "Connection closed"
-    | Some (Error e) -> Error (Printf.sprintf "Read error: %s" e)
-    | Some (Ok msg) ->
-      begin match msg with
-      | Jsonrpc.Response resp when resp.id = expected_id ->
-        Ok resp.result
-      | Jsonrpc.Error err when err.id = expected_id ->
-        Error err.error.message
-      | Jsonrpc.Request req ->
-        dispatch_server_request t req;
-        loop ()
-      | Jsonrpc.Notification notif ->
-        if notif.method_ = Notifications.cancelled then begin
-          (* Check if cancellation targets our in-flight request *)
-          let matches = match notif.params with
-            | Some (`Assoc fields) ->
-              begin match List.assoc_opt "requestId" fields with
-              | Some id_json ->
-                (match Jsonrpc.id_of_yojson id_json with
-                 | Ok id -> id = expected_id
-                 | Error _ -> false)
-              | None -> false
-              end
-            | _ -> false
-          in
-          if matches then
-            let reason = match notif.params with
-              | Some (`Assoc fields) ->
-                (match List.assoc_opt "reason" fields with
-                 | Some (`String r) -> Some r
-                 | _ -> None)
-              | _ -> None
-            in
-            Error (Printf.sprintf "Request cancelled%s"
-              (match reason with Some r -> ": " ^ r | None -> ""))
-          else begin
-            (* Cancellation for a different request; pass to handler and continue *)
-            (match t.notification_handler with
-             | Some handler ->
-               (try handler notif.method_ notif.params
-                with
-                | Out_of_memory | Stack_overflow as exn -> raise exn
-                | exn ->
-                  Printf.eprintf "Client: notification handler raised: %s\n%!"
-                    (Printexc.to_string exn))
-             | None -> ());
-            loop ()
-          end
-        end else begin
-          (* Normal notification handling *)
-          (match t.notification_handler with
-           | Some handler ->
-             (try handler notif.method_ notif.params
-              with
-              | Out_of_memory | Stack_overflow as exn -> raise exn
-              | exn ->
-                Printf.eprintf "Client: notification handler raised: %s\n%!"
-                  (Printexc.to_string exn))
-           | None -> ());
-          loop ()
-        end
-      | _ ->
-        loop ()
-      end
-  in
-  loop ()
-
-let send_notification t ~method_ ?params () =
-  let msg = Jsonrpc.make_notification ~method_ ?params () in
-  Stdio_transport.write t.transport msg
-
-let send_request t ~method_ ?params ?(timeout = default_timeout) () =
-  let id = Jsonrpc.Int (Atomic.fetch_and_add t.next_id 1) in
-  let msg = Jsonrpc.make_request ~id ~method_ ?params () in
-  match Stdio_transport.write t.transport msg with
-  | Error e -> Error e
-  | Ok () ->
-    match t.timeout_fn with
-    | None -> read_response t id
-    | Some tf ->
-      begin try
-        tf.run timeout (fun () -> read_response t id)
-      with Eio.Time.Timeout ->
-        (* Best effort: notify peer we gave up — guard against transport errors *)
-        (try
-          ignore (send_notification t
-            ~method_:Notifications.cancelled
-            ~params:(`Assoc [
-              ("requestId", Jsonrpc.id_to_yojson id);
-              ("reason", `String "Request timed out")
-            ]) ())
-        with
-        | Out_of_memory | Stack_overflow as exn -> raise exn
-        | _exn -> ());
-        Error (Printf.sprintf "Request timed out after %.1fs" timeout)
-      end
-
-(* ── initialize ───────────────────────────────────── *)
-
-let initialize t ~client_name ~client_version =
-  let params = Handler.build_initialize_params
-    ~has_sampling:(Option.is_some t.sampling_handler)
-    ~has_roots:(Option.is_some t.roots_handler)
-    ~has_elicitation:(Option.is_some t.elicitation_handler)
-    ~client_name ~client_version
-  in
-  match send_request t ~method_:Notifications.initialize ~params () with
-  | Error e -> Error e
-  | Ok result ->
-    match send_notification t ~method_:Notifications.initialized () with
-    | Error e -> Error (Printf.sprintf "Failed to send initialized notification: %s" e)
-    | Ok () -> Mcp_types.initialize_result_of_yojson result
-
-(* ── ping ─────────────────────────────────────────── *)
-
-let ping t =
-  match send_request t ~method_:Notifications.ping () with
-  | Error e -> Error e
-  | Ok _ -> Ok ()
-
-(* ── pagination helper ────────────────────────────── *)
-
-let list_all_pages t ~method_ ~field ~of_yojson =
-  Pagination.collect_pages (fun cursor ->
-    let params = Option.map (fun c -> `Assoc [("cursor", `String c)]) cursor in
-    match send_request t ~method_ ?params () with
-    | Error e -> Error e
-    | Ok result ->
-      Handler.parse_paginated_list_field field of_yojson result)
-
-(* ── tools ────────────────────────────────────────── *)
-
-let list_tools ?cursor t =
-  let params = match cursor with
-    | Some c -> Some (`Assoc [("cursor", `String c)])
-    | None -> None
-  in
-  match send_request t ~method_:Notifications.tools_list ?params () with
-  | Error e -> Error e
-  | Ok result ->
-    Result.map fst
-      (Handler.parse_paginated_list_field "tools" Mcp_types.tool_of_yojson result)
-
-let list_tools_all t =
-  list_all_pages t ~method_:Notifications.tools_list
-    ~field:"tools" ~of_yojson:Mcp_types.tool_of_yojson
-
-let call_tool t ~name ?arguments () =
-  let params_fields = [("name", `String name)] in
-  let params_fields = match arguments with
-    | Some args -> params_fields @ [("arguments", args)]
-    | None -> params_fields
-  in
-  let params = `Assoc params_fields in
-  match send_request t ~method_:Notifications.tools_call ~params () with
-  | Error e -> Error e
-  | Ok result -> Mcp_types.tool_result_of_yojson result
-
-(* ── resources ────────────────────────────────────── *)
-
-let list_resources ?cursor t =
-  let params = match cursor with
-    | Some c -> Some (`Assoc [("cursor", `String c)])
-    | None -> None
-  in
-  match send_request t ~method_:Notifications.resources_list ?params () with
-  | Error e -> Error e
-  | Ok result ->
-    Result.map fst
-      (Handler.parse_paginated_list_field "resources" Mcp_types.resource_of_yojson result)
-
-let list_resources_all t =
-  list_all_pages t ~method_:Notifications.resources_list
-    ~field:"resources" ~of_yojson:Mcp_types.resource_of_yojson
-
-let read_resource t ~uri =
-  let params = `Assoc [("uri", `String uri)] in
-  match send_request t ~method_:Notifications.resources_read ~params () with
-  | Error e -> Error e
-  | Ok result -> Handler.parse_list_field "contents" Mcp_types.resource_contents_of_yojson result
-
-let subscribe_resource t ~uri =
-  let params = `Assoc [("uri", `String uri)] in
-  match send_request t ~method_:Notifications.resources_subscribe ~params () with
-  | Error e -> Error e
-  | Ok _ -> Ok ()
-
-let unsubscribe_resource t ~uri =
-  let params = `Assoc [("uri", `String uri)] in
-  match send_request t ~method_:Notifications.resources_unsubscribe ~params () with
-  | Error e -> Error e
-  | Ok _ -> Ok ()
-
-let list_resource_templates ?cursor t =
-  let params = match cursor with
-    | Some c -> Some (`Assoc [("cursor", `String c)])
-    | None -> None
-  in
-  match send_request t ~method_:Notifications.resources_templates_list ?params () with
-  | Error e -> Error e
-  | Ok result ->
-    Handler.parse_list_field "resourceTemplates" Mcp_types.resource_template_of_yojson result
-
-(* ── prompts ──────────────────────────────────────── *)
-
-let list_prompts ?cursor t =
-  let params = match cursor with
-    | Some c -> Some (`Assoc [("cursor", `String c)])
-    | None -> None
-  in
-  match send_request t ~method_:Notifications.prompts_list ?params () with
-  | Error e -> Error e
-  | Ok result ->
-    Result.map fst
-      (Handler.parse_paginated_list_field "prompts" Mcp_types.prompt_of_yojson result)
-
-let list_prompts_all t =
-  list_all_pages t ~method_:Notifications.prompts_list
-    ~field:"prompts" ~of_yojson:Mcp_types.prompt_of_yojson
-
-let get_prompt t ~name ?arguments () =
-  let params_fields = [("name", `String name)] in
-  let params_fields = match arguments with
-    | Some pairs ->
-      let args_json = `Assoc (List.map (fun (k, v) -> (k, `String v)) pairs) in
-      params_fields @ [("arguments", args_json)]
-    | None -> params_fields
-  in
-  let params = `Assoc params_fields in
-  match send_request t ~method_:Notifications.prompts_get ~params () with
-  | Error e -> Error e
-  | Ok result -> Mcp_types.prompt_result_of_yojson result
-
-(* ── tasks ────────────────────────────────────────── *)
-
-let get_task t ~task_id =
-  let params = `Assoc [("taskId", `String task_id)] in
-  match send_request t ~method_:Notifications.tasks_get ~params () with
-  | Error e -> Error e
-  | Ok result -> Mcp_types.task_of_yojson result
-
-let get_task_result t ~task_id =
-  let params = `Assoc [("taskId", `String task_id)] in
-  match send_request t ~method_:Notifications.tasks_result ~params () with
-  | Error e -> Error e
-  | Ok result -> Ok result
-
-let list_tasks ?cursor t =
-  let params = match cursor with
-    | Some c -> Some (`Assoc [("cursor", `String c)])
-    | None -> None
-  in
-  match send_request t ~method_:Notifications.tasks_list ?params () with
-  | Error e -> Error e
-  | Ok result -> Handler.parse_list_field "tasks" Mcp_types.task_of_yojson result
-
-let cancel_task t ~task_id =
-  let params = `Assoc [("taskId", `String task_id)] in
-  match send_request t ~method_:Notifications.tasks_cancel ~params () with
-  | Error e -> Error e
-  | Ok result -> Mcp_types.task_of_yojson result
-
-(* ── close ────────────────────────────────────────── *)
-
-let close t =
-  Stdio_transport.close t.transport
+let close = Base.close

--- a/eio/handler.ml
+++ b/eio/handler.ml
@@ -126,12 +126,18 @@ let parse_list_field field_name parser result =
   | `Assoc fields ->
     begin match List.assoc_opt field_name fields with
     | Some (`List items) ->
-      let parsed = List.filter_map (fun j ->
-        match parser j with
-        | Ok v -> Some v
-        | Error _ -> None
-      ) items in
-      Ok parsed
+      List.mapi
+        (fun idx j ->
+          parser j |> Result.map_error (fun err ->
+              Printf.sprintf "Invalid '%s' item at index %d: %s"
+                field_name idx err))
+        items
+      |> List.fold_left
+           (fun acc item ->
+             Result.bind acc (fun parsed ->
+                 Result.bind item (fun value -> Ok (value :: parsed))))
+           (Ok [])
+      |> Result.map List.rev
     | _ -> Error (Printf.sprintf "Missing '%s' array in response" field_name)
     end
   | _ -> Error "Invalid response format"

--- a/eio/handler.mli
+++ b/eio/handler.mli
@@ -106,7 +106,7 @@ val add_task_handlers : task_handlers -> t -> t
 (** {2 Shared Client Helpers} *)
 
 (** Parse a JSON list field from a response, applying [parser] to each element.
-    Silently drops items that fail to parse. *)
+    Returns [Error] on the first invalid item instead of silently dropping it. *)
 val parse_list_field :
   string ->
   (Yojson.Safe.t -> ('a, string) result) ->

--- a/lib/sampling.ml
+++ b/lib/sampling.ml
@@ -12,6 +12,65 @@ let role_to_yojson = Mcp_types.role_to_yojson
 
 let role_of_yojson = Mcp_types.role_of_yojson
 
+let ( let* ) = Result.bind
+
+let expect_object what = function
+  | `Assoc fields -> Ok fields
+  | _ -> Error (what ^ " must be an object")
+
+let required_field what fields key =
+  match List.assoc_opt key fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "%s: missing '%s' field" what key)
+
+let optional_field fields key = List.assoc_opt key fields
+
+let parse_required what fields key parser =
+  let* value = required_field what fields key in
+  parser value |> Result.map_error (fun err ->
+      Printf.sprintf "%s.%s: %s" what key err)
+
+let parse_optional what fields key parser =
+  match optional_field fields key with
+  | None -> Ok None
+  | Some value ->
+      parser value
+      |> Result.map (fun parsed -> Some parsed)
+      |> Result.map_error (fun err ->
+             Printf.sprintf "%s.%s: %s" what key err)
+
+let parse_string what value =
+  match value with
+  | `String s -> Ok s
+  | _ -> Error (what ^ " must be a string")
+
+let parse_float what value =
+  match value with
+  | `Float f -> Ok f
+  | `Int i -> Ok (float_of_int i)
+  | _ -> Error (what ^ " must be a float")
+
+let parse_int what value =
+  match value with
+  | `Int i -> Ok i
+  | _ -> Error (what ^ " must be an int")
+
+let parse_string_list what value =
+  match value with
+  | `List items ->
+      List.mapi
+        (fun idx item ->
+          parse_string (Printf.sprintf "%s[%d]" what idx) item)
+        items
+      |> List.fold_left
+           (fun acc item ->
+             let* parsed = acc in
+             let* value = item in
+             Ok (value :: parsed))
+           (Ok [])
+      |> Result.map List.rev
+  | _ -> Error (what ^ " must be an array")
+
 (** Content types for sampling messages. *)
 type sampling_content =
   | Text of { type_: string; text: string }
@@ -24,19 +83,24 @@ let sampling_content_to_yojson = function
     `Assoc [("type", `String type_); ("data", `String data); ("mimeType", `String mime_type)]
 
 let sampling_content_of_yojson = function
-  | `Assoc fields ->
-    let open Yojson.Safe.Util in
-    let type_ = List.assoc "type" fields |> to_string in
-    (match type_ with
-     | "text" ->
-       let text = List.assoc "text" fields |> to_string in
-       Ok (Text { type_; text })
-     | "image" ->
-       let data = List.assoc "data" fields |> to_string in
-       let mime_type = List.assoc "mimeType" fields |> to_string in
-       Ok (Image { type_; data; mime_type })
-     | _ -> Error ("Unknown sampling content type: " ^ type_))
-  | _ -> Error "sampling_content must be an object"
+  | json ->
+    let* fields = expect_object "sampling_content" json in
+    let* type_ = parse_required "sampling_content" fields "type" (parse_string "type") in
+    match type_ with
+    | "text" ->
+        let* text =
+          parse_required "sampling_content" fields "text" (parse_string "text")
+        in
+        Ok (Text { type_; text })
+    | "image" ->
+        let* data =
+          parse_required "sampling_content" fields "data" (parse_string "data")
+        in
+        let* mime_type =
+          parse_required "sampling_content" fields "mimeType" (parse_string "mimeType")
+        in
+        Ok (Image { type_; data; mime_type })
+    | _ -> Error ("Unknown sampling content type: " ^ type_)
 
 (** A message in the sampling conversation. *)
 type sampling_message = {
@@ -51,13 +115,13 @@ let sampling_message_to_yojson msg =
   ]
 
 let sampling_message_of_yojson = function
-  | `Assoc fields ->
-    (match role_of_yojson (List.assoc "role" fields),
-           sampling_content_of_yojson (List.assoc "content" fields)
-     with
-     | Ok role, Ok content -> Ok { role; content }
-     | Error e, _ | _, Error e -> Error e)
-  | _ -> Error "sampling_message must be an object"
+  | json ->
+      let* fields = expect_object "sampling_message" json in
+      let* role = parse_required "sampling_message" fields "role" role_of_yojson in
+      let* content =
+        parse_required "sampling_message" fields "content" sampling_content_of_yojson
+      in
+      Ok { role; content }
 
 (** Model preferences for sampling. *)
 type model_preferences = {
@@ -107,29 +171,41 @@ let model_preferences_to_yojson p =
   `Assoc fields
 
 let model_preferences_of_yojson = function
-  | `Assoc fields ->
-    let hints = match List.assoc_opt "hints" fields with
-      | Some (`List l) ->
-        let parsed = List.filter_map (fun j ->
-          match model_hint_of_yojson j with
-          | Ok h -> Some h
-          | Error _ -> None
-        ) l in
-        Some parsed
-      | _ -> None
-    in
-    let float_opt key = match List.assoc_opt key fields with
-      | Some (`Float f) -> Some f
-      | Some (`Int i) -> Some (float_of_int i)
-      | _ -> None
-    in
-    Ok {
-      hints;
-      cost_priority = float_opt "costPriority";
-      speed_priority = float_opt "speedPriority";
-      intelligence_priority = float_opt "intelligencePriority";
-    }
-  | _ -> Error "model_preferences must be an object"
+  | json ->
+      let* fields = expect_object "model_preferences" json in
+      let parse_hints value =
+        match value with
+        | `List items ->
+            List.mapi
+              (fun idx item ->
+                model_hint_of_yojson item
+                |> Result.map_error (fun err ->
+                       Printf.sprintf "hints[%d]: %s" idx err))
+              items
+            |> List.fold_left
+                 (fun acc item ->
+                   let* parsed = acc in
+                   let* hint = item in
+                   Ok (hint :: parsed))
+                 (Ok [])
+            |> Result.map List.rev
+        | _ -> Error "hints must be an array"
+      in
+      let* hints = parse_optional "model_preferences" fields "hints" parse_hints in
+      let* cost_priority =
+        parse_optional "model_preferences" fields "costPriority" (parse_float "costPriority")
+      in
+      let* speed_priority =
+        parse_optional "model_preferences" fields "speedPriority" (parse_float "speedPriority")
+      in
+      let* intelligence_priority =
+        parse_optional
+          "model_preferences"
+          fields
+          "intelligencePriority"
+          (parse_float "intelligencePriority")
+      in
+      Ok { hints; cost_priority; speed_priority; intelligence_priority }
 
 (** Tool choice for sampling: auto, none, or a specific tool. *)
 type sampling_tool_choice =
@@ -174,20 +250,18 @@ let sampling_tool_to_yojson t =
   `Assoc fields
 
 let sampling_tool_of_yojson = function
-  | `Assoc fields ->
-    (match List.assoc_opt "name" fields with
-     | Some (`String name) ->
-       let description = match List.assoc_opt "description" fields with
-         | Some (`String s) -> Some s
-         | _ -> None
-       in
-       let input_schema = match List.assoc_opt "inputSchema" fields with
-         | Some j -> j
-         | None -> `Assoc [("type", `String "object")]
-       in
-       Ok { name; description; input_schema }
-     | _ -> Error "sampling_tool: missing 'name' field")
-  | _ -> Error "sampling_tool must be an object"
+  | json ->
+      let* fields = expect_object "sampling_tool" json in
+      let* name = parse_required "sampling_tool" fields "name" (parse_string "name") in
+      let* description =
+        parse_optional "sampling_tool" fields "description" (parse_string "description")
+      in
+      let input_schema =
+        match optional_field fields "inputSchema" with
+        | Some json -> json
+        | None -> `Assoc [("type", `String "object")]
+      in
+      Ok { name; description; input_schema }
 
 (** Which context the sampling host should include with the request. *)
 type include_context = None_ | ThisServer | AllServers
@@ -263,51 +337,104 @@ let create_message_params_to_yojson p =
   `Assoc fields
 
 let create_message_params_of_yojson = function
-  | `Assoc fields ->
-    let open Yojson.Safe.Util in
-    let messages_json = List.assoc "messages" fields |> to_list in
-    let messages = List.fold_left (fun acc j ->
-      match acc, sampling_message_of_yojson j with
-      | Ok acc, Ok msg -> Ok (msg :: acc)
-      | Error e, _ | _, Error e -> Error e
-    ) (Ok []) messages_json in
-    (match messages with
-     | Ok msgs ->
-       let msgs = List.rev msgs in
-       let max_tokens = List.assoc "maxTokens" fields |> to_int in
-       Ok {
-         messages = msgs;
-         model_preferences = (match List.assoc_opt "modelPreferences" fields with
-           | Some j -> (match model_preferences_of_yojson j with Ok p -> Some p | Error _ -> None)
-           | None -> None);
-         system_prompt = (match List.assoc_opt "systemPrompt" fields with
-           | Some (`String s) -> Some s | _ -> None);
-         include_context = (match List.assoc_opt "includeContext" fields with
-           | Some j -> (match include_context_of_yojson j with Ok ic -> Some ic | Error _ -> None)
-           | None -> None);
-         temperature = (match List.assoc_opt "temperature" fields with
-           | Some (`Float f) -> Some f | Some (`Int i) -> Some (float_of_int i) | _ -> None);
-         max_tokens;
-         stop_sequences = (match List.assoc_opt "stopSequences" fields with
-           | Some (`List l) -> Some (List.map to_string l) | _ -> None);
-         metadata = List.assoc_opt "metadata" fields;
-         tools = (match List.assoc_opt "tools" fields with
-           | Some (`List l) ->
-             let parsed = List.filter_map (fun j ->
-               match sampling_tool_of_yojson j with
-               | Ok t -> Some t | Error _ -> None
-             ) l in
-             if parsed = [] then None else Some parsed
-           | _ -> None);
-         tool_choice = (match List.assoc_opt "toolChoice" fields with
-           | Some j -> (match sampling_tool_choice_of_yojson j with
-             | Ok tc -> Some tc | Error _ -> None)
-           | None -> None);
-         _meta = (match List.assoc_opt "_meta" fields with
-           | Some (`Null) -> None | Some j -> Some j | None -> None);
-       }
-     | Error e -> Error e)
-  | _ -> Error "create_message_params must be an object"
+  | json ->
+      let* fields = expect_object "create_message_params" json in
+      let parse_messages value =
+        match value with
+        | `List items ->
+            List.mapi
+              (fun idx item ->
+                sampling_message_of_yojson item
+                |> Result.map_error (fun err ->
+                       Printf.sprintf "messages[%d]: %s" idx err))
+              items
+            |> List.fold_left
+                 (fun acc item ->
+                   let* parsed = acc in
+                   let* message = item in
+                   Ok (message :: parsed))
+                 (Ok [])
+            |> Result.map List.rev
+        | _ -> Error "messages must be an array"
+      in
+      let parse_tools value =
+        match value with
+        | `List items ->
+            List.mapi
+              (fun idx item ->
+                sampling_tool_of_yojson item
+                |> Result.map_error (fun err ->
+                       Printf.sprintf "tools[%d]: %s" idx err))
+              items
+            |> List.fold_left
+                 (fun acc item ->
+                   let* parsed = acc in
+                   let* tool = item in
+                   Ok (tool :: parsed))
+                 (Ok [])
+            |> Result.map List.rev
+        | _ -> Error "tools must be an array"
+      in
+      let* messages = parse_required "create_message_params" fields "messages" parse_messages in
+      let* max_tokens =
+        parse_required "create_message_params" fields "maxTokens" (parse_int "maxTokens")
+      in
+      let* model_preferences =
+        parse_optional
+          "create_message_params"
+          fields
+          "modelPreferences"
+          model_preferences_of_yojson
+      in
+      let* system_prompt =
+        parse_optional "create_message_params" fields "systemPrompt" (parse_string "systemPrompt")
+      in
+      let* include_context =
+        parse_optional
+          "create_message_params"
+          fields
+          "includeContext"
+          include_context_of_yojson
+      in
+      let* temperature =
+        parse_optional "create_message_params" fields "temperature" (parse_float "temperature")
+      in
+      let* stop_sequences =
+        parse_optional
+          "create_message_params"
+          fields
+          "stopSequences"
+          (parse_string_list "stopSequences")
+      in
+      let* tools =
+        parse_optional "create_message_params" fields "tools" parse_tools
+      in
+      let* tool_choice =
+        parse_optional
+          "create_message_params"
+          fields
+          "toolChoice"
+          sampling_tool_choice_of_yojson
+      in
+      let _meta =
+        match optional_field fields "_meta" with
+        | Some `Null | None -> None
+        | Some value -> Some value
+      in
+      Ok
+        {
+          messages;
+          model_preferences;
+          system_prompt;
+          include_context;
+          temperature;
+          max_tokens;
+          stop_sequences;
+          metadata = optional_field fields "metadata";
+          tools;
+          tool_choice;
+          _meta;
+        }
 
 (** Result for sampling/createMessage. *)
 type create_message_result = {
@@ -335,20 +462,21 @@ let create_message_result_to_yojson r =
   `Assoc fields
 
 let create_message_result_of_yojson = function
-  | `Assoc fields ->
-    (match role_of_yojson (List.assoc "role" fields),
-           sampling_content_of_yojson (List.assoc "content" fields)
-     with
-     | Ok role, Ok content ->
-       let open Yojson.Safe.Util in
-       let model = List.assoc "model" fields |> to_string in
-       let stop_reason = match List.assoc_opt "stopReason" fields with
-         | Some (`String s) -> Some s
-         | _ -> None
-       in
-       let _meta = match List.assoc_opt "_meta" fields with
-         | Some (`Null) -> None | Some j -> Some j | None -> None
-       in
-       Ok { role; content; model; stop_reason; _meta }
-     | Error e, _ | _, Error e -> Error e)
-  | _ -> Error "create_message_result must be an object"
+  | json ->
+      let* fields = expect_object "create_message_result" json in
+      let* role = parse_required "create_message_result" fields "role" role_of_yojson in
+      let* content =
+        parse_required "create_message_result" fields "content" sampling_content_of_yojson
+      in
+      let* model =
+        parse_required "create_message_result" fields "model" (parse_string "model")
+      in
+      let* stop_reason =
+        parse_optional "create_message_result" fields "stopReason" (parse_string "stopReason")
+      in
+      let _meta =
+        match optional_field fields "_meta" with
+        | Some `Null | None -> None
+        | Some value -> Some value
+      in
+      Ok { role; content; model; stop_reason; _meta }

--- a/test/test_handler.ml
+++ b/test/test_handler.ml
@@ -243,7 +243,7 @@ let test_parse_list_field_reports_failures () =
   | Ok _ -> Alcotest.fail "expected invalid item error"
   | Error e ->
     Alcotest.(check bool) "mentions item index" true
-      (String.contains e '1')
+      (String.equal e "Invalid 'items' item at index 1: not string")
 
 (* ── build_initialize_params ─────────────────── *)
 

--- a/test/test_handler.ml
+++ b/test/test_handler.ml
@@ -236,14 +236,14 @@ let test_parse_list_field_missing () =
   Alcotest.(check bool) "missing field"
     true (Result.is_error (Handler.parse_list_field "items" parser json))
 
-let test_parse_list_field_drops_failures () =
+let test_parse_list_field_reports_failures () =
   let json = `Assoc [("items", `List [`String "ok"; `Int 42; `String "also"])] in
   let parser = function `String s -> Ok s | _ -> Error "not string" in
   match Handler.parse_list_field "items" parser json with
-  | Ok items ->
-    (* Int 42 silently dropped *)
-    Alcotest.(check (list string)) "filtered" ["ok"; "also"] items
-  | Error e -> Alcotest.fail e
+  | Ok _ -> Alcotest.fail "expected invalid item error"
+  | Error e ->
+    Alcotest.(check bool) "mentions item index" true
+      (String.contains e '1')
 
 (* ── build_initialize_params ─────────────────── *)
 
@@ -335,7 +335,7 @@ let () =
     "helpers", [
       Alcotest.test_case "parse_list_field" `Quick test_parse_list_field_success;
       Alcotest.test_case "parse_list_field missing" `Quick test_parse_list_field_missing;
-      Alcotest.test_case "parse_list_field drops" `Quick test_parse_list_field_drops_failures;
+      Alcotest.test_case "parse_list_field reports invalid item" `Quick test_parse_list_field_reports_failures;
       Alcotest.test_case "build_init_params" `Quick test_build_init_params;
     ];
   ]

--- a/test/test_sampling.ml
+++ b/test/test_sampling.ml
@@ -91,6 +91,15 @@ let test_model_preferences_minimal () =
     Alcotest.(check bool) "no cost" true (Option.is_none p'.cost_priority)
   | Error e -> Alcotest.fail e
 
+let test_model_preferences_invalid_hint_fails () =
+  let json =
+    `Assoc [
+      ("hints", `List [ `String "not-an-object" ]);
+    ]
+  in
+  Alcotest.(check bool) "invalid hint rejected" true
+    (Result.is_error (Sampling.model_preferences_of_yojson json))
+
 (* --- create_message_params --- *)
 
 let test_create_message_params_roundtrip () =
@@ -327,6 +336,7 @@ let () =
     "model_preferences", [
       Alcotest.test_case "full" `Quick test_model_preferences_full;
       Alcotest.test_case "minimal" `Quick test_model_preferences_minimal;
+      Alcotest.test_case "invalid hint fails" `Quick test_model_preferences_invalid_hint_fails;
     ];
     "sampling_tool_choice", [
       Alcotest.test_case "auto" `Quick test_sampling_tool_choice_auto;

--- a/test/test_sampling.ml
+++ b/test/test_sampling.ml
@@ -141,6 +141,28 @@ let test_create_message_params_minimal () =
     Alcotest.(check bool) "no system" true (Option.is_none p'.system_prompt)
   | Error e -> Alcotest.fail e
 
+let test_create_message_params_invalid_tool_fails () =
+  let json =
+    `Assoc [
+      ("messages", `List []);
+      ("maxTokens", `Int 10);
+      ("tools", `List [ `Assoc [ ("description", `String "missing name") ] ]);
+    ]
+  in
+  Alcotest.(check bool) "invalid tool rejected" true
+    (Result.is_error (Sampling.create_message_params_of_yojson json))
+
+let test_create_message_params_invalid_include_context_fails () =
+  let json =
+    `Assoc [
+      ("messages", `List []);
+      ("maxTokens", `Int 10);
+      ("includeContext", `String "everywhere");
+    ]
+  in
+  Alcotest.(check bool) "invalid includeContext rejected" true
+    (Result.is_error (Sampling.create_message_params_of_yojson json))
+
 (* --- create_message_result --- *)
 
 let test_create_message_result_roundtrip () =
@@ -319,6 +341,8 @@ let () =
     "create_message_params", [
       Alcotest.test_case "roundtrip" `Quick test_create_message_params_roundtrip;
       Alcotest.test_case "minimal" `Quick test_create_message_params_minimal;
+      Alcotest.test_case "invalid tool fails" `Quick test_create_message_params_invalid_tool_fails;
+      Alcotest.test_case "invalid include_context fails" `Quick test_create_message_params_invalid_include_context_fails;
       Alcotest.test_case "with tools" `Quick test_create_message_params_with_tools;
       Alcotest.test_case "no tools omitted" `Quick test_create_message_params_no_tools;
     ];


### PR DESCRIPTION
## Summary
- replace the duplicated stdio client implementation with a thin wrapper over the generic client
- stop silently dropping malformed nested list and sampling payload items during decoding
- add regression tests for strict failure paths

## Verification
- `dune build --root . @install`
- `dune build --root . test/test_sampling.exe test/test_handler.exe test/test_client.exe`
- `./_build/default/test/test_sampling.exe`
- `./_build/default/test/test_handler.exe`
- `./_build/default/test/test_client.exe`

## Notes
- This is the first anti-pattern reduction wave focused on parse-at-the-boundary and removing lossy fallback behavior.