### PR TITLE
[codex] Sync release docs with the 1.3.0 line

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Single opam package `mcp_protocol` with three sub-libraries:
 
 ## Project Status
 
-- Current version: `1.1.0`
+- Current version: `1.3.0`
 - Roadmap: [ROADMAP.md](ROADMAP.md)
 - Release policy: [docs/RELEASE-POLICY.md](docs/RELEASE-POLICY.md)
 - Contribution guide and issue labels: [CONTRIBUTING.md](CONTRIBUTING.md)
@@ -181,7 +181,7 @@ Or add to your `dune-project`:
 
 ```lisp
 (depends
- (mcp_protocol (>= 1.1.0)))
+ (mcp_protocol (>= 1.3.0)))
 ```
 
 Then use sub-libraries in your `dune` file:

--- a/docs/RELEASE-POLICY.md
+++ b/docs/RELEASE-POLICY.md
@@ -2,8 +2,8 @@
 
 ## Stable line
 
-- The stable line is `1.0.x`.
-- Non-breaking additions and fixes go into the next patch release.
+- The stable line is `1.x`.
+- Non-breaking additions and fixes go into the next patch or minor release.
 - Breaking API changes require a minor or major version bump with explicit migration notes.
 
 ## Required metadata
@@ -12,8 +12,6 @@ Every release candidate must keep these files in sync:
 
 - `dune-project`
 - `mcp_protocol.opam`
-- `mcp_protocol_eio.opam`
-- `mcp_protocol_http.opam`
 - top release entry in `CHANGELOG.md`
 - `examples/conformance_server.ml`
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -12,7 +12,7 @@ opam pin add mcp_protocol git+https://github.com/jeong-sik/mcp-protocol-sdk.git
 
 ```lisp
 (depends
- (mcp_protocol (>= 0.1.0)))
+ (mcp_protocol (>= 1.3.0)))
 ```
 
 ## 소스 빌드


### PR DESCRIPTION
## What changed
- updated README to report the current SDK version as `1.3.0`
- updated README and `docs/SETUP.md` dependency examples to use `mcp_protocol >= 1.3.0`
- fixed `docs/RELEASE-POLICY.md` to reflect the single-package layout and the current stable `1.x` release line

## Why
The repository release metadata is already on `1.3.0`, but several public docs still described the old `1.1.0` line and the pre-merge multi-package layout. That made setup and release guidance internally inconsistent.

## Impact
- public docs now match the current release metadata
- setup guidance no longer points at stale minimum versions
- release policy no longer requires opam files that no longer exist

## Validation
- `bash scripts/check-release-metadata.sh`
- `dune build --root . @install`