### PR TITLE
[codex] normalize Accept media types case-insensitively

### DIFF
--- a/lib/http_negotiation.ml
+++ b/lib/http_negotiation.ml
@@ -35,12 +35,14 @@ let parse_media_type s =
     let type_parts = String.split_on_char '/' (String.trim type_part) in
     match type_parts with
     | [type_; subtype] ->
+      let type_ = String.lowercase_ascii (String.trim type_) in
+      let subtype = String.lowercase_ascii (String.trim subtype) in
       let quality, params =
         List.fold_left (fun (q, ps) param ->
           let param = String.trim param in
           match String.split_on_char '=' param with
           | [k; v] ->
-            let k = String.trim k in
+            let k = String.lowercase_ascii (String.trim k) in
             let v = String.trim v in
             if k = "q" then
               ((try float_of_string v with Failure _ -> 1.0), ps)
@@ -61,7 +63,9 @@ let parse_accept_header header =
 
 (** Check if media type matches a pattern (supports wildcards) *)
 let media_type_matches ~pattern ~actual =
-  let pattern_parts = String.split_on_char '/' pattern in
+  let pattern_parts =
+    String.split_on_char '/' (String.lowercase_ascii pattern)
+  in
   match pattern_parts with
   | [ptype; psubtype] ->
     (ptype = "*" || ptype = actual.type_) &&

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -18,6 +18,14 @@ let test_parse_with_quality () =
     Alcotest.(check (float 0.001)) "quality" 0.9 mt.quality
   | None -> Alcotest.fail "Failed to parse"
 
+let test_parse_case_insensitive () =
+  match Http_negotiation.parse_media_type "Application/JSON;Q=0.5" with
+  | Some mt ->
+    Alcotest.(check string) "type normalized" "application" mt.type_;
+    Alcotest.(check string) "subtype normalized" "json" mt.subtype;
+    Alcotest.(check (float 0.001)) "quality parsed" 0.5 mt.quality
+  | None -> Alcotest.fail "Failed to parse"
+
 let test_parse_with_params () =
   match Http_negotiation.parse_media_type "text/event-stream; charset=utf-8" with
   | Some mt ->
@@ -81,6 +89,8 @@ let test_media_type_no_match () =
 let test_accepts_sse () =
   Alcotest.(check bool) "sse header"
     true (Http_negotiation.accepts_sse "text/event-stream, application/json");
+  Alcotest.(check bool) "sse header case-insensitive"
+    true (Http_negotiation.accepts_sse "Text/Event-Stream, Application/JSON");
   Alcotest.(check bool) "no sse"
     false (Http_negotiation.accepts_sse "application/json");
   Alcotest.(check bool) "sse q=0 rejected (RFC 7231)"
@@ -91,6 +101,8 @@ let test_accepts_sse () =
 let test_accepts_json () =
   Alcotest.(check bool) "json header"
     true (Http_negotiation.accepts_json "application/json");
+  Alcotest.(check bool) "json header case-insensitive"
+    true (Http_negotiation.accepts_json "Application/JSON");
   Alcotest.(check bool) "wildcard accepts json"
     true (Http_negotiation.accepts_json "*/*");
   Alcotest.(check bool) "sse only"
@@ -196,6 +208,7 @@ let () =
     "parse_media_type", [
       Alcotest.test_case "simple" `Quick test_parse_simple;
       Alcotest.test_case "with quality" `Quick test_parse_with_quality;
+      Alcotest.test_case "case-insensitive" `Quick test_parse_case_insensitive;
       Alcotest.test_case "with params" `Quick test_parse_with_params;
       Alcotest.test_case "wildcard" `Quick test_parse_wildcard;
       Alcotest.test_case "invalid" `Quick test_parse_invalid;


### PR DESCRIPTION
## What changed
- normalize parsed Accept media types to lowercase
- treat parameter keys such as `Q=0.5` case-insensitively
- make media-type pattern matching case-insensitive
- add regression coverage for mixed-case Accept headers

## Why
`masc-mcp` should rely on the SDK parser as SSOT. The SDK parser needed to normalize HTTP header casing so downstream wrappers do not need to compensate.

## Impact
SDK consumers now get consistent Accept-header handling for mixed-case media types and parameter keys.

## Validation
- `dune build --root .`
- `./_build/default/test/test_http_negotiation.exe`
- `./_build/default/test/test_version.exe`